### PR TITLE
chore: add action for auto-adding issues and PRs to the project

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - opened
 

--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,0 +1,19 @@
+name: Automatically add ALL issues and pull requests to the IdeaForge project board
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue/PR to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/freeCodeCamp-2025-Summer-Hackathon/projects/22
+          github-token: ${{ secrets.ACTIONS_PROJECTS_WRITE_PAT }}


### PR DESCRIPTION
Create an action that automatically adds all issues and pull requests to the main project board. This is done so team members don't have to manually add each issue to the project.

<!--If pull request closes an issue, write its number in the place of XXXXXX.-->

Closes #30 