### PR TITLE
chore: add Bug Report and Feature Request issue templates

### DIFF
--- a/.github/bug-report.yaml
+++ b/.github/bug-report.yaml
@@ -1,0 +1,35 @@
+name: Bug Report
+description: Create a report to notify us about any bugs.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What was the expected outcome?
+      placeholder: Tell us what you see!
+      value: "Description:"
+    validations:
+      reqired: true
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: What browsers are you seeing the problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/feature-request.yaml
+++ b/.github/feature-request.yaml
@@ -1,0 +1,43 @@
+name: Feature Request
+description: Suggest a project idea.
+title: "[Feature]: "
+labels: ["enhancement"]
+
+body:
+  - type: textarea
+    id: feature-description
+    attributes:
+        label: Feature Description
+        description: Please describe the feature you would like in as much detail as possible
+        placeholder: Feature description
+        value: "Feature description:"
+    validations:
+      reqired: true
+  - type: textarea
+    id: motivation
+    attributes:
+        label: Motivation
+        description: Why do you feel this feature is necessary?
+        placeholder: Motivation
+        value: ""
+  - type: textarea
+    id: proposed-solution
+    attributes:
+        label: Proposed Solution
+        description: Describe the solution you'd like
+        placeholder: Solution
+        value: ""
+  - type: textarea
+    id: alternatives
+    attributes:
+        label: Alternatives Considered
+        description: Describe any alternative solutions or features you've considered
+        placeholder: Alternatives Considered
+        value: ""
+  - type: textarea
+    id: additional-context
+    attributes:
+        label: Additional Context
+        description: Add any other context, screenshots, or examples about the feature request here
+        placeholder: Additional Context
+        value: ""


### PR DESCRIPTION
Adds basic Issue templates - both in .yaml, it should make filling out Feature Requests more convenient (probably).

<!--If pull request closes an issue, write its number in the place of XXXXXX.-->

Closes #14