### PR TITLE
feat: login placeholders

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
-import Header from './components/Header.jsx';
-import Footer from './components/Footer.jsx';
-import IdeaFormSection from './components/IdeaFormSection.jsx';
-import IdeaSubmissionForm from './components/IdeaSubmissionForm.jsx';
-import LandingPageContent from './components/LandingPageContent.jsx';
-import HelpPage from './components/HelpPage.jsx';
+import Header from './components/Header';
+import Footer from './components/Footer';
+import IdeaFormSection from './components/IdeaFormSection';
+import IdeaSubmissionForm from './components/IdeaSubmissionForm';
+import LandingPageContent from './components/LandingPageContent';
+import HelpPage from './components/HelpPage';
+import LoginPage from './pages/LoginPage';
 import './styles.css';
 
 function App() {
@@ -33,6 +34,7 @@ function App() {
             }
           />
           <Route path='/help' element={<HelpPage />} />
+          <Route path='/login' element={<LoginPage />} />
         </Routes>
         <Footer />
       </div>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,7 +1,10 @@
+import { useRef } from 'react';
 import { useUser } from '../hooks/useUser';
+import LoginForm from './LoginForm';
 
 const Header = () => {
-  const { isLogged, login, logout } = useUser();
+  const dialogRef = useRef();
+  const { isLogged, logout } = useUser();
 
   return (
     <header className='header-style'>
@@ -45,10 +48,25 @@ const Header = () => {
             <>
               <button
                 className='auth-button login-button'
-                onClick={() => login({ name: 'placeholder' })}
+                onClick={() => {
+                  dialogRef.current.showModal();
+                }}
               >
                 Login
               </button>
+              <dialog ref={dialogRef} className='modal'>
+                <div className='modal-box'>
+                  <LoginForm />
+                  <form method='dialog'>
+                    <button className='btn btn-sm btn-circle btn-ghost absolute right-2 top-2'>
+                      ✕
+                    </button>
+                  </form>
+                </div>
+                <form method='dialog' className='modal-backdrop'>
+                  <button>close</button>
+                </form>
+              </dialog>
               <button className='auth-button not-logged-in-button active'>
                 Not Logged In
               </button>

--- a/frontend/src/components/LoginForm.jsx
+++ b/frontend/src/components/LoginForm.jsx
@@ -1,0 +1,50 @@
+import { useForm } from 'react-hook-form';
+import { useUser } from '../hooks/useUser';
+
+export const LoginForm = () => {
+  const {
+    formState: { isSubmitting, isValid },
+    handleSubmit,
+    register,
+  } = useForm();
+  const { login } = useUser();
+
+  const onSubmit = async data => {
+    console.log('data', data);
+    login({ name: 'placeholder' });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <label className='floating-label'>
+        <span>Username</span>
+        <input
+          {...register('username')}
+          placeholder='Username'
+          className='input validator'
+          required
+        />
+      </label>
+
+      <label className='floating-label'>
+        <span>Password</span>
+        <input
+          {...register('password')}
+          type='Password'
+          placeholder='Password'
+          className='input validator'
+          minLength='8'
+          required
+        />
+      </label>
+      <button
+        className='btn btn-xs sm:btn-sm md:btn-md lg:btn-lg xl:btn-xl'
+        {...((isSubmitting || !isValid) && { disabled: 'disabled' })}
+      >
+        {isSubmitting && <span className='loading loading-spinner'></span>}Login
+      </button>
+    </form>
+  );
+};
+
+export default LoginForm;

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,0 +1,20 @@
+import { Link } from 'react-router';
+import { LoginForm } from '../components/LoginForm';
+import { useUser } from '../hooks/useUser';
+
+export const LoginPage = () => {
+  const { isLogged } = useUser();
+
+  if (isLogged) {
+    return <section>Already logged in</section>;
+  }
+
+  return (
+    <section>
+      <LoginForm />
+      Not registered? <Link to='/register'>Sign up</Link>
+    </section>
+  );
+};
+
+export default LoginPage;


### PR DESCRIPTION
- Adds `/login` page.
- Adds login form. (_Login_ action is still a placeholder, but non-empty user and at least 8 characters password need to be entered.)
- Adds modal displaying login form afer clicking the _Login_ button in header.
- Some styling borrowed from daisyUI (https://daisyui.com/components/input/, https://daisyui.com/components/button/, https://daisyui.com/components/modal/). Otherwise styling did not get any attention and it can be changed to whatever is necessary.

Ref: #20