### PR TITLE
build: replaced 'react-helmet-async' with '@dr.pogodin/react-helmet'

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,9 +14,9 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@dr.pogodin/react-helmet": "^3.0.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-helmet-async": "^2.0.5",
     "react-hook-form": "^7.59.0",
     "react-router": "^7.6.3",
     "react-router-dom": "^7.6.3",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
-import { Helmet } from 'react-helmet-async';
+import { Helmet } from '@dr.pogodin/react-helmet';
 import Header from './components/Header';
 import Footer from './components/Footer';
 import IdeaFormSection from './components/IdeaFormSection';

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { createRoot } from 'react-dom/client';
-import { HelmetProvider } from 'react-helmet-async';
+import { HelmetProvider} from '@dr.pogodin/react-helmet';
 
 import App from './App.jsx';
 import { UserProvider } from './user/UserProvider.jsx';


### PR DESCRIPTION
This removes the dependency on 'react-helmet-async' library and adds '@dr.pogodin/react-helmet' in its place. The new library is a continuation of the old one, written for React 19.

<!--If pull request closes an issue, write its number in the place of XXXXXX.-->

Closes #77