### PR TITLE
feat: pagination

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -43,6 +43,7 @@ function App() {
             <Route path=':ideaId' element={<IdeaPage />} />
             <Route path=':ideaId/edit' element={<IdeaEditPage />} />
             <Route path='add' element={<IdeaAddPage />} />
+            <Route path='page/:page' element={<IdeasPage />} />
           </Route>
         </Routes>
         <Footer />

--- a/frontend/src/components/Pagination.jsx
+++ b/frontend/src/components/Pagination.jsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+
+export const Pagination = ({
+  numberOfPages,
+  initialPage,
+  fetchFromApi,
+  getApiUrl,
+  getPageUrl,
+}) => {
+  const [currentPage, setCurPage] = useState(initialPage);
+  const pages = [...Array(numberOfPages).keys()];
+
+  const Href = ({ pageNo, text }) => {
+    const apiUrl = getApiUrl(pageNo);
+    const pageUrl = getPageUrl(pageNo);
+    const onClick = async e => {
+      e.preventDefault();
+      await fetchFromApi(apiUrl);
+      setCurPage(pageNo);
+      window.history.pushState(null, '', pageUrl);
+    };
+    return (
+      <a href={pageUrl} className='nav-link' onClick={onClick}>
+        {text}
+      </a>
+    );
+  };
+
+  const NavigateToPrevPage = ({ currentPage }) =>
+    currentPage <= 0 ? (
+      <span className='nav-link'>{'<'}</span>
+    ) : (
+      <Href pageNo={currentPage - 1} text={'<'} />
+    );
+
+  const NavigateToNextPage = ({ currentPage }) =>
+    currentPage >= numberOfPages - 1 ? (
+      <span className='nav-link'>{'>'}</span>
+    ) : (
+      <Href pageNo={currentPage + 1} text={'>'} />
+    );
+
+  return (
+    <div className='nav-list'>
+      <NavigateToPrevPage currentPage={currentPage} />
+      {pages.map(pageNo =>
+        currentPage !== pageNo ? (
+          <Href key={pageNo} pageNo={pageNo} text={pageNo + 1} />
+        ) : (
+          <a className='nav-link active' key={pageNo}>
+            {pageNo + 1}
+          </a>
+        )
+      )}
+      <NavigateToNextPage currentPage={currentPage} />
+    </div>
+  );
+};
+
+export default Pagination;

--- a/frontend/src/pages/Ideas/IdeasPage.jsx
+++ b/frontend/src/pages/Ideas/IdeasPage.jsx
@@ -1,7 +1,9 @@
+import { useParams } from 'react-router';
 import IdeaFormSection from '../../components/IdeaFormSection';
 
 export const IdeasPage = () => {
-  return <IdeaFormSection count={20} />;
+  const { page = 1 } = useParams('page');
+  return <IdeaFormSection {...{ count: 20, page: page - 1, paginate: true }} />;
 };
 
 export default IdeasPage;


### PR DESCRIPTION
- Adds Pagination component, it requires:
  - `numberOfPages` - total number of pages
  - `initialPage` - which page is _currently_ active
  - `fetchFromApi` - async function fetching, must accept accepts api url returned by `getApiUrl`
  - `getApiUrl` - function accepting page number and composing api url, to be used with `fetchFromApi` to fetch items from specific page.
  - `getPageUrl` - function accepting page number and composing page url, to be used in the buttons
- Adds pagination to the `/ideas/` page
- It doesn't memonize previously fetched entries yet.