### PR TITLE
feat: idea voting in frontend

### DIFF
--- a/backend/src/api/routes/ideas.py
+++ b/backend/src/api/routes/ideas.py
@@ -114,7 +114,7 @@ async def upvote_idea(
     if current_user.id in idea.upvoted_by or idea.id in current_user.upvotes:
         return idea
 
-    with suppress(KeyError):
+    with suppress(ValueError):
         idea.downvoted_by.remove(current_user.id)
         current_user.downvotes.remove(idea.id)
 
@@ -137,7 +137,7 @@ async def downvote_idea(
     if current_user.id in idea.downvoted_by or idea.id in current_user.downvotes:
         return idea
 
-    with suppress(KeyError):
+    with suppress(ValueError):
         idea.upvoted_by.remove(current_user.id)
         current_user.upvotes.remove(idea.id)
 

--- a/frontend/src/components/IdeaFormSection.jsx
+++ b/frontend/src/components/IdeaFormSection.jsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Link, NavLink } from 'react-router-dom';
-import UpvoteImg from '../assets/Upvote.svg';
+import { IdeaListItem } from './IdeaListItem';
 import { useApi } from '../hooks/useApi';
 import { Pagination } from './Pagination';
 import Spinny from './Spinny';
@@ -78,29 +77,9 @@ const IdeaFormSection = ({
           <ul className='idea-list'>
             {!entries || entries.length === 0
               ? "There's no ideas, add yours!"
-              : entries.map(({ id, name, upvoted_by }) => {
-                  return (
-                    <Link to={`/ideas/${id}`} key={id}>
-                      <li className='idea-item'>
-                        <span className='idea-text'>{name}</span>
-                        <div className='vote-controls'>
-                          <form onSubmit={() => {}}>
-                            <button className='image-only-upvote-button'>
-                              <img
-                                src={UpvoteImg}
-                                alt='Upvote'
-                                className='upvote-icon'
-                              />
-                            </button>
-                          </form>
-                          <span className='vote-count'>
-                            {upvoted_by?.length}
-                          </span>
-                        </div>
-                      </li>
-                    </Link>
-                  );
-                })}
+              : entries.map(entry => (
+                  <IdeaListItem key={entry.id} {...entry} />
+                ))}
           </ul>
         )}
         {paginate && showPages && entries.length > 0 && <>{pagination}</>}

--- a/frontend/src/components/IdeaListItem.jsx
+++ b/frontend/src/components/IdeaListItem.jsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import { Link } from 'react-router';
+
+import { UpvoteButton } from './VoteButtons';
+
+export const IdeaListItem = ({ id, name, upvoted_by }) => {
+  const [idea, setIdea] = useState({
+    id,
+    name,
+    upvotes: upvoted_by.length,
+  });
+  const [isUpvoted, setIsUpvoted] = useState(false);
+
+  const onSuccess = () => {
+    if (!isUpvoted) {
+      setIdea(idea => ({
+        ...idea,
+        upvotes: idea.upvotes + 1,
+      }));
+      setIsUpvoted(true);
+    }
+  };
+
+  const onError = error => {
+    console.error(error);
+  };
+
+  return (
+    <Link to={`/ideas/${idea.id}`}>
+      <li className='idea-item'>
+        <span className='idea-text'>{idea.name}</span>
+        <div className='vote-controls'>
+          <UpvoteButton {...{ ideaId: idea.id, onSuccess, onError }} />
+          <span className='vote-count'>{idea.upvotes}</span>
+        </div>
+      </li>
+    </Link>
+  );
+};
+
+export default IdeaListItem;

--- a/frontend/src/components/VoteButtons.jsx
+++ b/frontend/src/components/VoteButtons.jsx
@@ -1,0 +1,111 @@
+import { useApi } from '../hooks/useApi';
+import UpvoteImg from '../assets/Upvote.svg';
+import { useEffect, useState } from 'react';
+import Spinny from './Spinny';
+import { useUser } from '../hooks/useUser';
+
+const SuccessIcon = () => (
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    className='h-6 w-6 shrink-0 stroke-current'
+    fill='none'
+    width='100%'
+    height='100%'
+    viewBox='0 0 24 24'
+  >
+    <path
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      strokeWidth='2'
+      d='M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z'
+    />
+  </svg>
+);
+
+const Button = ({
+  ideaId,
+  fetchAddr,
+  buttonProps,
+  buttonContents,
+  onSuccess,
+  onError,
+}) => {
+  const { isLogged } = useUser();
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const { data, error, fetchFromApi } = useApi({ method: 'PUT' });
+
+  const onVote = async event => {
+    event.preventDefault();
+    setLoading(true);
+    try {
+      await fetchFromApi(fetchAddr, {
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ idea_id: ideaId }),
+      });
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  useEffect(() => {
+    if (data && !error) {
+      setSuccess(true);
+      setLoading(false);
+      onSuccess();
+    }
+    if (error) {
+      setLoading(false);
+      onError(error);
+    }
+  }, [data, error, onError, onSuccess, setLoading, setSuccess]);
+
+  return (
+    <div
+      {...(!isLogged && {
+        className: 'tooltip tooltip-warning',
+        'data-tip': 'Login to vote',
+      })}
+    >
+      <button
+        onClick={onVote}
+        {...((loading || success || !isLogged) && { disabled: true })}
+        {...buttonProps}
+      >
+        {loading ? <Spinny /> : success ? <SuccessIcon /> : buttonContents}
+      </button>
+    </div>
+  );
+};
+
+export const DownvoteButton = ({ ideaId, onSuccess, onError }) => (
+  <Button
+    {...{
+      buttonProps: {
+        className: 'image-only-downvote-button',
+      },
+      buttonContents: <>downvote</>,
+      fetchAddr: `/ideas/${ideaId}/downvote`,
+      ideaId,
+      onSuccess,
+      onError,
+    }}
+  />
+);
+
+export const UpvoteButton = ({ ideaId, onSuccess, onError }) => (
+  <Button
+    {...{
+      buttonProps: {
+        className: 'image-only-upvote-button',
+      },
+      buttonContents: (
+        <img src={UpvoteImg} alt='Upvote' className='upvote-icon' />
+      ),
+      fetchAddr: `/ideas/${ideaId}/upvote`,
+      ideaId,
+      onSuccess,
+      onError,
+    }}
+  />
+);

--- a/frontend/src/pages/Ideas/IdeaPage.jsx
+++ b/frontend/src/pages/Ideas/IdeaPage.jsx
@@ -1,38 +1,102 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 
 import { useApi } from '../../hooks/useApi';
 import Spinny from '../../components/Spinny';
+import { useUser } from '../../hooks/useUser';
+import { DownvoteButton, UpvoteButton } from '../../components/VoteButtons';
 
 export const IdeaPage = () => {
   const { ideaId } = useParams();
-  const { isLoading, error, data, fetchFromApi } = useApi({
+  const { isLogged } = useUser();
+  const [loading, setLoading] = useState(true);
+  const [isUpvoted, setIsUpvoted] = useState(false);
+  const [isDownvoted, setIsDownvoted] = useState(false);
+  const { error, data, fetchFromApi } = useApi({
     loadingInitially: true,
   });
+
+  const [idea, setIdea] = useState();
+
+  const onUpvoteSuccess = () => {
+    if (!isUpvoted) {
+      setIdea(idea => ({
+        ...idea,
+        upvotes: idea.upvotes + 1,
+        ...(isDownvoted && { downvotes: idea.downvotes - 1 }),
+      }));
+      setIsUpvoted(true);
+    }
+  };
+
+  const onError = error => {
+    console.error(error);
+  };
+
+  const onDownvoteSuccess = () => {
+    if (!isDownvoted) {
+      setIdea(idea => ({
+        ...idea,
+        downvotes: idea.downvotes + 1,
+        ...(isUpvoted && { upvotes: idea.upvotes - 1 }),
+      }));
+      setIsDownvoted(true);
+    }
+  };
+
+  useEffect(() => {
+    if (idea && loading) {
+      setLoading(false);
+    }
+  }, [idea, loading, setLoading]);
+
+  useEffect(() => {
+    if (data && loading) {
+      setIdea({
+        name: data?.name,
+        description: data?.description,
+        upvotes: data?.upvoted_by.length,
+        downvotes: data?.downvoted_by.length,
+      });
+      setLoading(false);
+    }
+  }, [data, loading, setLoading, setIdea]);
 
   useEffect(() => {
     fetchFromApi(`/ideas/${ideaId}`);
   }, [fetchFromApi, ideaId]);
 
-  return isLoading ? (
+  return loading ? (
     <Spinny />
   ) : error ? (
     <>{error}</>
   ) : (
     <section>
-      <h1 className='header'>{data?.name}</h1>
-      <p>{data?.description}</p>
+      <h1 className='header'>{idea?.name}</h1>
+      <p>{idea?.description}</p>
       <div className='stats stats-vertical lg:stats-horizontal shadow'>
         <div className='stat'>
           <div className='stat-title'>Upvotes</div>
-          <div className='stat-value'>{data?.upvoted_by.length}</div>
+          <div className='stat-value'>{idea?.upvotes}</div>
         </div>
 
         <div className='stat'>
           <div className='stat-title'>Downvotes</div>
-          <div className='stat-value'>{data?.downvoted_by.length}</div>
+          <div className='stat-value'>{idea?.downvotes}</div>
         </div>
       </div>
+      {isLogged && (
+        <>
+          <UpvoteButton {...{ ideaId, onSuccess: onUpvoteSuccess, onError }} />
+          <DownvoteButton
+            {...{
+              ideaId,
+              onSuccess: onDownvoteSuccess,
+              onError,
+            }}
+          />
+        </>
+      )}
     </section>
   );
 };


### PR DESCRIPTION
- Fixes name of suppressed exception.
- Adds component for idea list item.
- Adds (downvote) icon placeholder.
- Adds sending vote to the backend.
- After upvote/downvote count changes in the frontend. There's a bit indirection with that (injecting `onSuccess` and `onError` functions), so counts can be updated. 
- The previous user votes currently are not loaded to the react's state, so the _actual_ vote counts can differ by 1. (But that should be changed in further PRs)