### PR TITLE
feat: edit idea

### DIFF
--- a/backend/src/api/routes/ideas.py
+++ b/backend/src/api/routes/ideas.py
@@ -87,7 +87,7 @@ async def update_idea(
     idea = await db.find_one(Idea, Idea.id == id)
     if idea is None:
         raise HTTPException(status_code=404, detail="Idea not found")
-    if not current_user.is_admin or current_user.id != idea.creator_id:
+    if not current_user.is_admin and current_user.id != idea.creator_id:
         raise HTTPException(status_code=403, detail="Not enough permissions")
     idea.model_update(update_data)
     await db.save(idea)

--- a/backend/src/scripts/seed_data.py
+++ b/backend/src/scripts/seed_data.py
@@ -21,7 +21,15 @@ def generate_user() -> User:
 
 
 async def seed_users(num_users: int = 10) -> list[User]:
-    new_users = [generate_user() for _ in range(num_users)]
+    admin = User.model_validate(
+        {
+            "username": "adminUser",
+            "name": "Admin",
+            "hashed_password": get_password_hash("password"),
+            "is_admin": True,
+        }
+    )
+    new_users = [generate_user() for _ in range(num_users)] + [admin]
     engine = await get_engine()
     await engine.save_all(new_users)
     return new_users

--- a/frontend/src/components/IdeaForm.jsx
+++ b/frontend/src/components/IdeaForm.jsx
@@ -1,0 +1,144 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
+import { useForm } from 'react-hook-form';
+
+import Spinny from './Spinny';
+import { useUser } from '../hooks/useUser';
+
+const SuccessIcon = () => (
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    className='h-6 w-6 shrink-0 stroke-current'
+    fill='none'
+    viewBox='0 0 24 24'
+  >
+    <path
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      strokeWidth='2'
+      d='M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z'
+    />
+  </svg>
+);
+
+export const IdeaForm = ({
+  api,
+  buttonText,
+  disableButton,
+  headerText,
+  initialData,
+  onSubmit,
+}) => {
+  const [submitError, setSubmitError] = useState();
+  const { isLogged } = useUser();
+  const [loading, setLoading] = useState();
+  const [success, setSuccess] = useState();
+  const {
+    formState: { errors, isDirty },
+    handleSubmit,
+    register,
+  } = useForm({
+    defaultValues: {
+      name: initialData?.name,
+      description: initialData?.description,
+    },
+  });
+  const { data, error } = api;
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (data && !error) {
+      setSuccess(true);
+      navigate(`/ideas/${data.id}`);
+    }
+    if (error) {
+      setSubmitError(error.message);
+      setLoading(false);
+    }
+  }, [data, navigate, error, setSubmitError]);
+
+  const wrappedSubmit = async ideaData => {
+    setLoading(true);
+    await onSubmit(ideaData);
+  };
+
+  const buttonDisable = useMemo(
+    () => disableButton({ loading, success, isDirty, isLogged }),
+    [disableButton, loading, success, isDirty, isLogged]
+  );
+
+  return (
+    <>
+      <h2 className='idea-form-sub-heading'>{headerText}</h2>
+      <form className='idea-form' onSubmit={handleSubmit(wrappedSubmit)}>
+        <div className='form-group'>
+          <label htmlFor='idea-title' className='form-label'>
+            Idea Title: <span className='text-red-500'>*</span>
+          </label>
+          <input
+            {...register('name', { required: 'Idea Title is required' })}
+            type='text'
+            className='form-input'
+            placeholder='e.g., Dark Mode for IdeaForge'
+            required
+          />
+          {errors?.name && (
+            <p role='alert' className='text-error'>
+              {errors.name.message}
+            </p>
+          )}
+        </div>
+        <div className='form-group'>
+          <label htmlFor='idea-description' className='form-label'>
+            Idea Description: <span className='text-red-500'>*</span>
+          </label>
+          <textarea
+            {...register('description', {
+              required: 'Idea Description is required',
+            })}
+            className='form-textarea'
+            placeholder='Provide a detailed description of your idea, its benefits, and how it could be implemented.'
+            rows='6'
+            required
+          ></textarea>
+          {errors?.description && (
+            <p role='alert' className='text-error'>
+              {errors.description.message}
+            </p>
+          )}
+        </div>
+        {/* <div className='form-group'>
+          <label htmlFor='idea-category' className='form-label'>
+            Category:
+          </label>
+          <select
+            id='idea-category'
+            name='idea-category'
+            className='form-select'
+          >
+            <option value=''>Select a category</option>
+            <option value='feature-request'>Feature Request</option>
+            <option value='bug-report'>Bug Report</option>
+            <option value='design-idea'>Design Idea</option>
+            <option value='general-feedback'>General Feedback</option>
+            <option value='other'>Other</option>
+          </select>
+        </div> */}
+        <button
+          type='submit'
+          className='animated-button golden'
+          {...(!!buttonDisable && { disabled: true })}
+        >
+          {success ? <SuccessIcon /> : loading ? <Spinny /> : <>{buttonText}</>}
+        </button>
+        {submitError && (
+          <p role='alert' className='text-error'>
+            Error: {submitError}
+          </p>
+        )}
+      </form>
+    </>
+  );
+};
+
+export default IdeaForm;

--- a/frontend/src/components/IdeaForm.jsx
+++ b/frontend/src/components/IdeaForm.jsx
@@ -24,7 +24,7 @@ const SuccessIcon = () => (
 export const IdeaForm = ({
   api,
   buttonText,
-  disableButton,
+  disableSubmit,
   headerText,
   initialData,
   onSubmit,
@@ -62,9 +62,9 @@ export const IdeaForm = ({
     await onSubmit(ideaData);
   };
 
-  const buttonDisable = useMemo(
-    () => disableButton({ loading, success, isDirty, isLogged }),
-    [disableButton, loading, success, isDirty, isLogged]
+  const isSubmitDisabled = useMemo(
+    () => disableSubmit({ loading, success, isDirty, isLogged }),
+    [disableSubmit, loading, success, isDirty, isLogged]
   );
 
   return (
@@ -127,7 +127,7 @@ export const IdeaForm = ({
         <button
           type='submit'
           className='animated-button golden'
-          {...(!!buttonDisable && { disabled: true })}
+          {...(isSubmitDisabled && { disabled: true })}
         >
           {success ? <SuccessIcon /> : loading ? <Spinny /> : <>{buttonText}</>}
         </button>

--- a/frontend/src/components/IdeaSubmissionForm.jsx
+++ b/frontend/src/components/IdeaSubmissionForm.jsx
@@ -1,60 +1,12 @@
-import { useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router';
-
 import { useApi } from '../hooks/useApi';
-import { useUser } from '../hooks/useUser';
-import Spinny from './Spinny';
-
-const SuccessIcon = () => (
-  <svg
-    xmlns='http://www.w3.org/2000/svg'
-    className='h-6 w-6 shrink-0 stroke-current'
-    fill='none'
-    viewBox='0 0 24 24'
-  >
-    <path
-      strokeLinecap='round'
-      strokeLinejoin='round'
-      strokeWidth='2'
-      d='M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z'
-    />
-  </svg>
-);
+import { IdeaForm } from './IdeaForm';
 
 const IdeaSubmissionForm = () => {
-  const { isLogged } = useUser();
-  const [submitError, setSubmitError] = useState();
-  const [loading, setLoading] = useState();
-  const [success, setSuccess] = useState();
-  const {
-    formState: { errors },
-    handleSubmit,
-    register,
-  } = useForm();
-  const { data, error, fetchFromApi } = useApi({ method: 'POST' });
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (data && !error) {
-      setSuccess(true);
-      navigate(`/ideas/${data.id}`);
-    }
-    if (error) {
-      setSubmitError(error.message);
-      setLoading(false);
-    }
-  }, [data, navigate, error, setSubmitError]);
+  const api = useApi({ method: 'POST' });
 
   const onSubmit = async ideaData => {
-    setLoading(true);
-    if (!isLogged) {
-      setSubmitError('Please login to submit ideas');
-      setLoading(false);
-      return;
-    }
     try {
-      await fetchFromApi(`/ideas`, {
+      await api.fetchFromApi(`/ideas`, {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(ideaData),
       });
@@ -64,87 +16,16 @@ const IdeaSubmissionForm = () => {
   };
 
   return (
-    <>
-      <h2 className='idea-form-sub-heading'>Submit Your New Idea</h2>
-      <form className='idea-form' onSubmit={handleSubmit(onSubmit)}>
-        <div className='form-group'>
-          <label htmlFor='idea-title' className='form-label'>
-            Idea Title:
-          </label>
-          <input
-            {...register('name')}
-            type='text'
-            className='form-input'
-            placeholder='e.g., Dark Mode for IdeaForge'
-            required
-          />
-          {errors?.name && (
-            <p role='alert' className='text-error'>
-              {errors.name.message}
-            </p>
-          )}
-        </div>
-        <div className='form-group'>
-          <label htmlFor='idea-description' className='form-label'>
-            Idea Description:
-          </label>
-          <textarea
-            {...register('description')}
-            className='form-textarea'
-            placeholder='Provide a detailed description of your idea, its benefits, and how it could be implemented.'
-            rows='6'
-          ></textarea>
-          {errors?.description && (
-            <p role='alert' className='text-error'>
-              {errors.description.message}
-            </p>
-          )}
-        </div>
-        {/*         <div className='form-group'>
-          <label htmlFor='idea-category' className='form-label'>
-            Category:
-          </label>
-          <select
-            id='idea-category'
-            name='idea-category'
-            className='form-select'
-          >
-            <option value=''>Select a category</option>
-            <option value='feature-request'>Feature Request</option>
-            <option value='bug-report'>Bug Report</option>
-            <option value='design-idea'>Design Idea</option>
-            <option value='general-feedback'>General Feedback</option>
-            <option value='other'>Other</option>
-          </select>
-        </div> */}
-        <div
-          style={{ width: 'fit-content', alignSelf: 'center' }}
-          {...(!isLogged && {
-            className: 'tooltip tooltip-warning',
-            'data-tip': 'Login to add ideas',
-          })}
-        >
-          <button
-            type='submit'
-            className='animated-button golden'
-            {...((loading || success || !isLogged) && { disabled: true })}
-          >
-            {success ? (
-              <SuccessIcon />
-            ) : loading ? (
-              <Spinny />
-            ) : (
-              <>Start Your IdeaForge</>
-            )}
-          </button>
-        </div>
-        {submitError && (
-          <p role='alert' className='text-error'>
-            Error: {submitError}
-          </p>
-        )}
-      </form>
-    </>
+    <IdeaForm
+      {...{
+        api,
+        disableButton: ({ loading, success, isLogged }) =>
+          loading || success || !isLogged,
+        buttonText: 'Start Your IdeaForge',
+        headerText: 'Submit Your New Idea',
+        onSubmit,
+      }}
+    />
   );
 };
 

--- a/frontend/src/components/IdeaSubmissionForm.jsx
+++ b/frontend/src/components/IdeaSubmissionForm.jsx
@@ -19,7 +19,7 @@ const IdeaSubmissionForm = () => {
     <IdeaForm
       {...{
         api,
-        disableButton: ({ loading, success, isLogged }) =>
+        disableSubmit: ({ loading, success, isLogged }) =>
           loading || success || !isLogged,
         buttonText: 'Start Your IdeaForge',
         headerText: 'Submit Your New Idea',

--- a/frontend/src/pages/Ideas/IdeaEditPage.jsx
+++ b/frontend/src/pages/Ideas/IdeaEditPage.jsx
@@ -44,7 +44,7 @@ export const IdeaEditPage = () => {
       {...{
         api,
         initialData: data,
-        disableButton: ({ loading, success, isDirty }) =>
+        disableSubmit: ({ loading, success, isDirty }) =>
           loading || success || !isDirty,
         buttonText: 'Edit Idea',
         headerText: 'Edit Idea',

--- a/frontend/src/pages/Ideas/IdeaEditPage.jsx
+++ b/frontend/src/pages/Ideas/IdeaEditPage.jsx
@@ -1,8 +1,59 @@
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
+
+import { useApi } from '../../hooks/useApi';
+import { useUser } from '../../hooks/useUser';
+import { IdeaForm } from '../../components/IdeaForm';
+import Spinny from '../../components/Spinny';
 
 export const IdeaEditPage = () => {
   const { ideaId } = useParams();
-  return <>edit {ideaId}</>;
+  const { isAdmin, userState } = useUser();
+  const [loading, setLoading] = useState(true);
+  const { data, error, isLoading, fetchFromApi } = useApi({
+    loadingInitially: true,
+  });
+
+  useEffect(() => {
+    if (data && !error && !isLoading && loading) {
+      setLoading(false);
+    }
+  }, [data, error, isLoading, loading, setLoading]);
+
+  useEffect(() => {
+    fetchFromApi(`/ideas/${ideaId}`);
+  }, [fetchFromApi, ideaId]);
+
+  const api = useApi({ method: 'PATCH' });
+
+  const onSubmit = async ideaData => {
+    try {
+      await api.fetchFromApi(`/ideas/${ideaId}`, {
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(ideaData),
+      });
+    } catch (e) {
+      console.error('error', e);
+    }
+  };
+
+  return loading ? (
+    <Spinny />
+  ) : isAdmin || data?.creator_id === userState.id ? (
+    <IdeaForm
+      {...{
+        api,
+        initialData: data,
+        disableButton: ({ loading, success, isDirty }) =>
+          loading || success || !isDirty,
+        buttonText: 'Edit Idea',
+        headerText: 'Edit Idea',
+        onSubmit,
+      }}
+    />
+  ) : (
+    <>Access denied</>
+  );
 };
 
 export default IdeaEditPage;

--- a/frontend/src/pages/Ideas/IdeaPage.jsx
+++ b/frontend/src/pages/Ideas/IdeaPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router';
+import { Link, useParams } from 'react-router';
 
 import { useApi } from '../../hooks/useApi';
 import Spinny from '../../components/Spinny';
@@ -8,7 +8,7 @@ import { DownvoteButton, UpvoteButton } from '../../components/VoteButtons';
 
 export const IdeaPage = () => {
   const { ideaId } = useParams();
-  const { isLogged, userState, upvote, downvote } = useUser();
+  const { isAdmin, isLogged, userState, upvote, downvote } = useUser();
   const [loading, setLoading] = useState(true);
   const [isUpvoted, setIsUpvoted] = useState(userState.upvotes.has(ideaId));
   const [isDownvoted, setIsDownvoted] = useState(
@@ -57,6 +57,7 @@ export const IdeaPage = () => {
   useEffect(() => {
     if (data && loading) {
       setIdea({
+        creatorId: data?.creator_id,
         name: data?.name,
         description: data?.description,
         upvotes: data?.upvoted_by.length,
@@ -102,6 +103,11 @@ export const IdeaPage = () => {
             }}
           />
         </div>
+      )}
+      {(isAdmin || userState.id === idea.creatorId) && (
+        <Link className='animated-button' to={`edit`}>
+          Edit
+        </Link>
       )}
     </section>
   );


### PR DESCRIPTION
- Editing idea.
- Button to edit is displayed on idea page for admin and creator of the idea.
- Adds user with admin permissions to the seed script - username: `adminUser`, password: `password`.
- There's a bit playing around with indirection to reuse the extracted `IdeaForm`, it's a bit awkward. Among other things, it requires `onSubmit` function which triggers the api call, `api` - whole object returned from the `useApi` (which is destructured inside of the form for `data` and `errors`), `disableSubmit` function - accepting object with various states and based on them (one or more) determines if submit button should be disabled (returns boolean).