### PR TITLE
fix: pass parameters to retried request

### DIFF
--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -77,7 +77,7 @@ export const useApi = ({ method = 'GET', loadingInitially = false }) => {
               responseJson.detail.includes('Missing Cookie')
             ) {
               await getCrsfToken({ forceNew: true });
-              return await sendRequest();
+              return await sendRequest(path, extraFetchOptions);
             }
             setData(responseJson);
           } catch (e) {


### PR DESCRIPTION
- Retries were directed always to the `/`.