### PR TITLE
feat: add user information to '/me' page

### DIFF
--- a/frontend/src/pages/MePage.jsx
+++ b/frontend/src/pages/MePage.jsx
@@ -1,10 +1,44 @@
+import { useState } from 'react';
+import { useUser } from '../hooks/useUser';
+import { Link } from 'react-router';
+
 const MePage = () => {
+  const { isLogged, userState } = useUser();
+  const [loggedUser] = useState(userState);
   return (
     <div className='section-card flex flex-col items-center justify-center min-h-[60vh]'>
-      <h1 className='section-heading'>My Profile</h1>
-      <p className='text-lg text-gray-600 mb-8'>
-        This page will display user profile information.
-      </p>
+      {isLogged ? (
+        <>
+          <h1 className='section-heading'>{loggedUser.name}'s Profile</h1>
+          <div className='h-full w-full text-lg text-gray-600 mb-8 flex flex-col'>
+            <p>
+              <span className='font-bold'>Account Name:</span> {loggedUser.username}
+              {loggedUser.is_admin && <span> (Admin)</span>}
+            </p>
+            <p>
+              <span className='font-bold'>Upvotes:</span>{' '}
+              {loggedUser.upvotes.size}
+            </p>
+            <p>
+              <span className='font-bold'>Downvotes:</span>{' '}
+              {loggedUser.downvotes.size}
+            </p>
+            <Link className='underline' to='/me/ideas'>
+              My ideas
+            </Link>
+            <Link className='underline' to='/me/edit'>
+              Edit Profile
+            </Link>
+          </div>
+        </>
+      ) : (
+        <>
+          <h1 className='section-heading'>No access</h1>
+          <p className='text-lg text-gray-600 mb-8'>
+            You have to be logged in to see this page!
+          </p>
+        </>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
This adds basic user information, like account name, admin role indication, and number of upvotes/downvotes to the '/me' page, and links to 'My Ideas' and 'edit profile' pages (they're doubled in the drop-down menu, but hopefully it will make navigation easier). If the user is not logged in, the page will show a notification they can't see the page unless they're logged in.

<!--If pull request closes an issue, write its number in the place of XXXXXX.-->

Closes #165