### PR TITLE
fix: throw when refresh fails

### DIFF
--- a/frontend/src/user/UserProvider.jsx
+++ b/frontend/src/user/UserProvider.jsx
@@ -73,11 +73,12 @@ export const UserProvider = ({ children }) => {
                 credentials: 'include',
               }
             );
-            if (refresh_response.ok) {
-              const data = await refresh_response.json();
-              localStorage.setItem('access_token', data.access_token);
-              return fetchUser();
+            if (!refresh_response.ok) {
+              throw new Error(refresh_response.statusText);
             }
+            const data = await refresh_response.json();
+            localStorage.setItem('access_token', data.access_token);
+            return fetchUser();
           } else {
             throw new Error(response.statusText);
           }


### PR DESCRIPTION
- Response from the refresh was getting lost, instead error which was being caught, was due to attempt of getting `json` from the initial response.