### PR TITLE
chore: return more data for admin user listing

### DIFF
--- a/backend/src/api/routes/users.py
+++ b/backend/src/api/routes/users.py
@@ -7,7 +7,14 @@ from odmantic.exceptions import DuplicateKeyError
 from src.api.dependencies import AdminUser
 from src.auth import get_password_hash
 from src.dependencies import Db
-from src.models import User, UserEditPatch, UserPublic, UserRegister, UsersPublic
+from src.models import (
+    User,
+    UserEditPatch,
+    UserMe,
+    UserPublic,
+    UserRegister,
+    UsersAdmin,
+)
 
 router = APIRouter(prefix="/users")
 
@@ -36,14 +43,14 @@ async def create_user(db: Db, register_data: Annotated[UserRegister, Form()]):
 
 @router.get(
     "/",
-    response_model=UsersPublic,
+    response_model=UsersAdmin,
     dependencies=[AdminUser],
 )
 async def list_users(db: Db, skip: int = 0, limit: int = 20):
-    users = await db.find(User, limit=limit, skip=skip)
+    users = await db.find(User, limit=limit, skip=skip, sort=User.name)
     count = await db.count(User)
-    return UsersPublic(
-        users=[UserPublic(**user.model_dump()) for user in users], count=count
+    return UsersAdmin(
+        users=[UserMe(**user.model_dump()) for user in users], count=count
     )
 
 

--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -22,6 +22,11 @@ class UserMe(BaseModel):
     downvotes: list[ObjectId]
 
 
+class UsersAdmin(BaseModel):
+    users: list[UserMe]
+    count: int
+
+
 class UserPublic(BaseModel):
     id: ObjectId
     name: str = Field(max_length=255)


### PR DESCRIPTION
- Api returns more info about user for the admin user listing.
- To be specific:
https://github.com/freeCodeCamp-2025-Summer-Hackathon/mint-syntax/blob/d7ddede8828f416fa50278dab9a33301adb62135/backend/src/models.py#L15-L22