### PR TITLE
fix: dark mode issue

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1147,3 +1147,31 @@ button:disabled:hover,
   transform: none;
   border-color: var(--palette-borders-separators);
 }
+
+.form-input,
+.form-textarea,
+.form-select {
+  background-color: var(--palette-accent-white) !important;
+  color: var(--palette-primary-text) !important;
+  border-color: var(--palette-borders-separators) !important;
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: var(--palette-secondary-text);
+}
+
+@media (prefers-color-scheme: dark) {
+  input[type='text'],
+  input[type='email'],
+  input[type='password'],
+  textarea,
+  select,
+  .form-input,
+  .form-textarea,
+  .form-select {
+    background-color: var(--palette-accent-white) !important;
+    color: var(--palette-primary-text) !important;
+    border-color: var(--palette-borders-separators) !important;
+  }
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1162,16 +1162,14 @@ textarea::placeholder {
 }
 
 @media (prefers-color-scheme: dark) {
-  input[type='text'],
-  input[type='email'],
-  input[type='password'],
-  textarea,
-  select,
-  .form-input,
-  .form-textarea,
-  .form-select {
-    background-color: var(--palette-accent-white) !important;
-    color: var(--palette-primary-text) !important;
-    border-color: var(--palette-borders-separators) !important;
+   :root {
+    --color-base-content: oklch(21% 0.006 285.885);
+    --base-color-100: oklch(100% 0 0);
+  }
+  
+  .bg-base-100,
+  .input,
+  .modal-box {
+    background-color: var(--palette-accent-white);
   }
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1162,11 +1162,11 @@ textarea::placeholder {
 }
 
 @media (prefers-color-scheme: dark) {
-   :root {
+  :root {
     --color-base-content: oklch(21% 0.006 285.885);
     --base-color-100: oklch(100% 0 0);
   }
-  
+
   .bg-base-100,
   .input,
   .modal-box {


### PR DESCRIPTION
The changes I made explicitly override the browser's default dark mode behavior for input fields, text areas, and select elements, ensuring they remain in our light color scheme. This was done to address the issue of inconsistent styling when a full dark mode feature hasn't still implemented.

<!--If pull request closes an issue, write its number in the place of XXXXXX.-->

Closes #178 