### PR TITLE
chore: add link to login button

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -94,14 +94,16 @@ const Header = () => {
             </>
           ) : (
             <>
-              <button
+              <Link
                 className='auth-button login-button'
-                onClick={() => {
+                to='/login'
+                onClick={e => {
+                  e.preventDefault();
                   dialogRef.current.showModal();
                 }}
               >
                 Login
-              </button>
+              </Link>
               <dialog ref={dialogRef} className='modal'>
                 <div className='modal-box'>
                   <LoginForm />


### PR DESCRIPTION
- When _Login_ button is clicked - dialog is shown.
- Button still has link to the `/login`, so it can be opened in new window, and/or copied.