### PR TITLE
fix: force Tailwind CSS to use 'light mode'

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="light">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1160,16 +1160,3 @@ input::placeholder,
 textarea::placeholder {
   color: var(--palette-secondary-text);
 }
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-base-content: oklch(21% 0.006 285.885);
-    --base-color-100: oklch(100% 0 0);
-  }
-
-  .bg-base-100,
-  .input,
-  .modal-box {
-    background-color: var(--palette-accent-white);
-  }
-}


### PR DESCRIPTION
This removes the current css styles meant to fix the 'dark mode' overrides, and forces Tailwind to use light mode at all times instead.
It will prevent the need to add overrides each time any of the Tailwind CSS or DaisyUI predefined colors are used.