### PR TITLE
chore: separate admin user edit from user edit

### DIFF
--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -45,7 +45,13 @@ class UserRegister(BaseModel):
 
 class UserEditPatch(BaseModel):
     name: str | None = Field(max_length=255)
+    password: str | None = None
+    hashed_password: str | None = None
+
+
+class AdminUserEditPatch(UserEditPatch):
     is_active: bool | None = None
+    is_admin: bool | None = None
 
 
 class Idea(Model):


### PR DESCRIPTION
- Separates admin user edit from user... user edit.
- Admin is able to edit `is_active` or `is_admin`, but user is not.
- Admin user edit uses PATCH `/users/{id}`, User user edit uses PATCH `/me`.