### PR TITLE
chore: return 503 when mongodb is not running

### DIFF
--- a/backend/src/database.py
+++ b/backend/src/database.py
@@ -1,7 +1,9 @@
 from typing import Any
 
+from fastapi import HTTPException
 from motor.motor_asyncio import AsyncIOMotorClient
 from odmantic import AIOEngine
+from pymongo.errors import ServerSelectionTimeoutError
 
 from src.config import get_settings
 from src.models import Idea, User
@@ -17,6 +19,9 @@ async def get_engine() -> AIOEngine:
 
 
 async def get_db():
-    engine = await get_engine()
-    async with engine.session() as session:
-        yield session
+    try:
+        engine = await get_engine()
+        async with engine.session() as session:
+            yield session
+    except ServerSelectionTimeoutError as e:
+        raise HTTPException(status_code=503) from e


### PR DESCRIPTION
- Returns HTTP 503 when mongodb is not running.
- Might address #121