### PR TITLE
fix: verify old password only when non-empty

### DIFF
--- a/backend/src/api/routes/me.py
+++ b/backend/src/api/routes/me.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from fastapi import APIRouter, HTTPException
 
 from src.api.dependencies import LoggedInUser
-from src.auth import User, get_password_hash
+from src.auth import User, get_password_hash, verify_password
 from src.dependencies import Db
 from src.models import Idea, IdeaPublic, IdeasPublic, UserEditPatch, UserMe
 
@@ -21,8 +21,8 @@ async def patch_me(
     current_user: Annotated[User, LoggedInUser],
     update_data: UserEditPatch,
 ):
-    if update_data.new_password is not None and update_data.old_password is not None:
-        if get_password_hash(update_data.old_password) != current_user.hashed_password:
+    if update_data.new_password and update_data.old_password:
+        if not verify_password(update_data.old_password, current_user.hashed_password):
             raise HTTPException(status_code=403, detail="Invalid password")
         update_data.hashed_password = get_password_hash(update_data.new_password)
     current_user.model_update(update_data, exclude={"new_password", "old_password"})


### PR DESCRIPTION
- Verifies `old_password` only when `old_password` and `new_password` are non-empty. This includes the non-included in request default `None`, and included empty string, when password is not changed in form.
- Ref https://github.com/freeCodeCamp-2025-Summer-Hackathon/mint-syntax/pull/200#issuecomment-3124715514