### PR TITLE
refactor: pass function fetching page to Pagination

### DIFF
--- a/frontend/src/components/IdeasList.jsx
+++ b/frontend/src/components/IdeasList.jsx
@@ -57,10 +57,11 @@ const IdeasList = ({
       <Pagination
         {...{
           numberOfPages: totalPages,
-          fetchFromApi,
-          getApiUrl,
           getPageUrl,
           initialPage: page,
+          fetchPage: async page => {
+            await fetchFromApi(getApiUrl(page));
+          },
         }}
       />
     ),

--- a/frontend/src/components/Pagination.jsx
+++ b/frontend/src/components/Pagination.jsx
@@ -3,19 +3,17 @@ import { useState } from 'react';
 export const Pagination = ({
   numberOfPages,
   initialPage,
-  fetchFromApi,
-  getApiUrl,
   getPageUrl,
+  fetchPage,
 }) => {
   const [currentPage, setCurPage] = useState(initialPage);
   const pages = [...Array(numberOfPages).keys()];
 
   const Href = ({ pageNo, text }) => {
-    const apiUrl = getApiUrl(pageNo);
     const pageUrl = getPageUrl(pageNo);
     const onClick = async e => {
       e.preventDefault();
-      await fetchFromApi(apiUrl);
+      await fetchPage(pageNo);
       setCurPage(pageNo);
       window.history.pushState(null, '', pageUrl);
     };

--- a/frontend/src/pages/UsersPage.jsx
+++ b/frontend/src/pages/UsersPage.jsx
@@ -80,9 +80,10 @@ const UsersPage = ({ count = 20 }) => {
               <Pagination
                 numberOfPages={totalPages}
                 initialPage={currentPage}
-                fetchFromApi={fetchFromApi}
-                getApiUrl={getApiUrl}
                 getPageUrl={getPageUrl}
+                fetchPage={async page => {
+                  await fetchFromApi(getApiUrl(page));
+                }}
               />
             </div>
           )}


### PR DESCRIPTION
- Instead of `getApiUrl` and `fetchFromApi`, `Pagination` requires now `fetchPage` - async function fetching specific page.