### PR TITLE
chore: enable eslint react plugin rules

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,5 +1,6 @@
 import js from '@eslint/js';
 import globals from 'globals';
+import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import { defineConfig, globalIgnores } from 'eslint/config';
@@ -10,6 +11,8 @@ export default defineConfig([
     files: ['**/*.{js,jsx}'],
     extends: [
       js.configs.recommended,
+      react.configs.flat.recommended,
+      react.configs.flat['jsx-runtime'],
       reactHooks.configs['recommended-latest'],
       reactRefresh.configs.vite,
     ],
@@ -24,6 +27,7 @@ export default defineConfig([
     },
     rules: {
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'react/prop-types': 0,
     },
   },
 ]);

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -31,7 +31,8 @@ class ErrorBoundary extends React.Component {
         <div className='error-boundary-fallback'>
           <h1>Something went wrong.</h1>
           <p>
-            We're sorry for the inconvenience. Please try refreshing the page.
+            We&apos;re sorry for the inconvenience. Please try refreshing the
+            page.
           </p>
           {import.meta.env.DEV && this.state.error && (
             <details style={{ whiteSpace: 'pre-wrap' }}>

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -4,7 +4,11 @@ const Footer = () => {
       <div className='footer-content'>
         <p>
           &copy;{' '}
-          <a href='https://www.freecodecamp.org' target='_blank'>
+          <a
+            href='https://www.freecodecamp.org'
+            target='_blank'
+            rel='noreferrer noopener'
+          >
             freeCodeCamp Summer Hackathon 2025 | mint-sytax team
           </a>
         </p>
@@ -12,6 +16,7 @@ const Footer = () => {
           <a
             href='https://github.com/freeCodeCamp-2025-Summer-Hackathon/mint-syntax'
             target='_blank'
+            rel='noreferrer noopener'
             aria-label='GitHub'
             className='social-link'
           >

--- a/frontend/src/components/LoginForm.jsx
+++ b/frontend/src/components/LoginForm.jsx
@@ -100,7 +100,7 @@ export function LoginForm({ redirect_to = '/', dialogRef }) {
         </div>
         {errors.username?.type === 'required' && (
           <p role='alert' className='text-error'>
-            The field "Username" is required.
+            The field &quot;Username&quot; is required.
           </p>
         )}
 
@@ -122,7 +122,7 @@ export function LoginForm({ redirect_to = '/', dialogRef }) {
         </div>
         {errors.password?.type === 'required' && (
           <p role='alert' className='text-error'>
-            The field "Password" is required.
+            The field &quot;Password&quot; is required.
           </p>
         )}
 

--- a/frontend/src/components/RegisterForm.jsx
+++ b/frontend/src/components/RegisterForm.jsx
@@ -107,7 +107,7 @@ export function RegisterForm({ redirect_to = '/' }) {
       </div>
       {errors.username?.type === 'required' ? (
         <p role='alert' className='text-error text-xs mt-0.5'>
-          The field "Username" is required.
+          The field &quot;Username&quot; is required.
         </p>
       ) : (
         error &&
@@ -136,7 +136,7 @@ export function RegisterForm({ redirect_to = '/' }) {
       </div>
       {errors.name?.type === 'required' && (
         <p role='alert' className='text-error text-xs mt-0.5'>
-          The field "Name" is required.
+          The field &quot;Name&quot; is required.
         </p>
       )}
 
@@ -158,7 +158,7 @@ export function RegisterForm({ redirect_to = '/' }) {
       </div>
       {errors.password?.type === 'required' ? (
         <p role='alert' className='text-error text-xs mt-0.5'>
-          The field "Password" is required.
+          The field &quot;Password&quot; is required.
         </p>
       ) : (
         errors.password?.type === 'minLength' && (
@@ -190,7 +190,7 @@ export function RegisterForm({ redirect_to = '/' }) {
       </div>
       {errors.repeatPassword?.type === 'required' ? (
         <p role='alert' className='text-error text-xs mt-0.5'>
-          The field "Repeat Password" is required.
+          The field &quot;Repeat Password&quot; is required.
         </p>
       ) : (
         errors.repeatPassword?.type === 'validate' && (

--- a/frontend/src/pages/HelpPage.jsx
+++ b/frontend/src/pages/HelpPage.jsx
@@ -27,7 +27,7 @@ const HelpPage = () => {
       <div className='faq-section'>
         <h3>Frequently Asked Questions</h3>
         {faq.map(({ question, answer }) => (
-          <div className='faq-item'>
+          <div className='faq-item' key={question}>
             <h4>{question}</h4>
             <p>{answer}</p>
           </div>
@@ -37,8 +37,8 @@ const HelpPage = () => {
       <div className='contact-section'>
         <h3>Still have questions?</h3>
         <p>
-          If you can't find what you're looking for, please reach out to our
-          support team:
+          If you can&apos;t find what you&apos;re looking for, please reach out
+          to our support team:
         </p>
         <p>
           Email:{' '}

--- a/frontend/src/pages/LogoutPage.jsx
+++ b/frontend/src/pages/LogoutPage.jsx
@@ -4,7 +4,7 @@ export default function LogoutPage() {
   return (
     <div className='max-w-md mx-auto mt-16 p-6 bg-[#f4fdf9] rounded-lg shadow-lg border border-[#cdeee3]'>
       <h1 className='text-2xl font-bold mb-4 text-center text-[#317c67]'>
-        👋 You're logged out
+        👋 You&apos;re logged out
       </h1>
       <p className='mb-6 text-gray-600 text-center'>
         Thanks for using Idea Forge. You can log in again below.

--- a/frontend/src/pages/MeEditPage.jsx
+++ b/frontend/src/pages/MeEditPage.jsx
@@ -105,7 +105,9 @@ const MeEditPage = () => {
         <Spinny />
       ) : (
         <>
-          <h1 className='section-heading'>Edit {headerUserName}'s Profile</h1>
+          <h1 className='section-heading'>
+            Edit {headerUserName}&apos;s Profile
+          </h1>
 
           <form
             className='w-full max-w-xl p-4 bg-base-200 rounded-lg shadow-md'
@@ -133,7 +135,7 @@ const MeEditPage = () => {
 
             {errors.username?.type === 'required' ? (
               <p role='alert' className='text-error'>
-                The field "Username" is required.
+                The field &quot;Username&quot; is required.
               </p>
             ) : (
               error &&

--- a/frontend/src/pages/MePage.jsx
+++ b/frontend/src/pages/MePage.jsx
@@ -30,7 +30,7 @@ const MePage = () => {
           <>`${error}`</>
         ) : (
           <>
-            <h1 className='section-heading'>{data.name}'s Profile</h1>
+            <h1 className='section-heading'>{data.name}&apos;s Profile</h1>
             <p>
               <span className='font-bold'>Account Name:</span> {data.username}
               {isAdmin && <span> (Admin)</span>}


### PR DESCRIPTION
- Well, this is awkward.
- Enable react specific eslint rules.
- Other changes are fixing the issues.
- Feature referred in `react/prop-types` is depreciated in React 19, so rule needs to be disabled.