### PR TITLE
chore: components wrapping buttons

### DIFF
--- a/frontend/src/components/Buttons.jsx
+++ b/frontend/src/components/Buttons.jsx
@@ -1,0 +1,27 @@
+const Button = ({ type, disabled, additionalClasses, children, ...props }) => {
+  const className =
+    'animated-button !text-base !px-5 !py-2' +
+    (additionalClasses ? ' ' + additionalClasses : '');
+  return (
+    <button
+      type={type}
+      className={className}
+      {...(disabled && { disabled: true })}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+
+export const SubmitButton = ({ children, ...props }) => (
+  <Button type='submit' {...props}>
+    {children}
+  </Button>
+);
+
+export const ActionButton = ({ children, ...props }) => (
+  <Button type='button' {...props}>
+    {children}
+  </Button>
+);

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -5,6 +5,7 @@ import LoginForm from './LoginForm';
 import ScrollToHashElement from './ScrollToHashElement';
 import IdeaForgeLogo from '../assets/Idea-Forge-logo.svg';
 import { ChevronIcon } from './Icons/ChevronIcon';
+import { ActionButton } from './Buttons';
 
 const Header = () => {
   const dialogRef = useRef();
@@ -58,13 +59,13 @@ const Header = () => {
           {isLogged ? (
             <>
               <div className='dropdown'>
-                <button
+                <ActionButton
                   tabIndex={0}
                   className='auth-button logged-in-button active'
                 >
                   User: {userState.name}
                   <ChevronIcon />
-                </button>
+                </ActionButton>
                 <ul
                   tabIndex={0}
                   className='menu dropdown-content dropdown-main-brand-green'

--- a/frontend/src/components/IdeaForm.jsx
+++ b/frontend/src/components/IdeaForm.jsx
@@ -5,6 +5,7 @@ import { useForm } from 'react-hook-form';
 import Spinny from './Spinny';
 import { SuccessIcon } from './Icons/SuccessIcon';
 import { useUser } from '../hooks/useUser';
+import { SubmitButton } from './Buttons';
 
 export const IdeaForm = ({
   api,
@@ -109,13 +110,20 @@ export const IdeaForm = ({
             <option value='other'>Other</option>
           </select>
         </div> */}
-        <button
-          type='submit'
-          className='animated-button golden'
-          {...(isSubmitDisabled && { disabled: true })}
-        >
-          {success ? <SuccessIcon /> : loading ? <Spinny /> : <>{buttonText}</>}
-        </button>
+        <div className='flex justify-center'>
+          <SubmitButton
+            additionalClasses='!text-xl golden'
+            disabled={isSubmitDisabled}
+          >
+            {success ? (
+              <SuccessIcon />
+            ) : loading ? (
+              <Spinny />
+            ) : (
+              <>{buttonText}</>
+            )}
+          </SubmitButton>
+        </div>
         {submitError && (
           <p role='alert' className='text-error'>
             Error: {submitError}

--- a/frontend/src/components/LoginForm.jsx
+++ b/frontend/src/components/LoginForm.jsx
@@ -5,6 +5,7 @@ import { UserIcon } from './Icons/UserIcon';
 import { PasswordIcon } from './Icons/PasswordIcon';
 import { useApi } from '../hooks/useApi';
 import { useUser } from '../hooks/useUser';
+import { SubmitButton } from './Buttons';
 
 export function LoginForm({ redirect_to = '/', dialogRef }) {
   const formRef = useRef();
@@ -102,13 +103,10 @@ export function LoginForm({ redirect_to = '/', dialogRef }) {
         )}
 
         <div className='flex justify-center'>
-          <button
-            className='my-1 animated-button'
-            {...((isSubmitting || !isValid) && { disabled: 'disabled' })}
-          >
+          <SubmitButton disabled={isSubmitting || !isValid}>
             {isSubmitting && <span className='loading loading-spinner'></span>}
             Login
-          </button>
+          </SubmitButton>
         </div>
       </form>
 

--- a/frontend/src/components/RegisterForm.jsx
+++ b/frontend/src/components/RegisterForm.jsx
@@ -5,6 +5,7 @@ import { PasswordIcon } from './Icons/PasswordIcon';
 import { UserIcon } from './Icons/UserIcon';
 import { useApi } from '../hooks/useApi';
 import { useUser } from '../hooks/useUser';
+import { SubmitButton } from './Buttons';
 
 export function RegisterForm({ redirect_to = '/' }) {
   const formRef = useRef();
@@ -167,12 +168,7 @@ export function RegisterForm({ redirect_to = '/' }) {
       )}
 
       <div className='flex justify-center'>
-        <button
-          className='my-1 animated-button'
-          {...(isSubmitting && { disabled: 'disabled' })}
-        >
-          Register
-        </button>
+        <SubmitButton disabled={isSubmitting}>Register</SubmitButton>
       </div>
     </form>
   );

--- a/frontend/src/components/VoteButtons.jsx
+++ b/frontend/src/components/VoteButtons.jsx
@@ -5,8 +5,9 @@ import { useEffect, useState } from 'react';
 import Spinny from './Spinny';
 import { SuccessIcon } from './Icons/SuccessIcon';
 import { useUser } from '../hooks/useUser';
+import { ActionButton } from './Buttons';
 
-const Button = ({
+const VoteButton = ({
   ideaId,
   fetchAddr,
   buttonProps: { className, ...restButtonProps } = {},
@@ -62,7 +63,7 @@ const Button = ({
         'data-tip': 'Already voted!',
       })}
     >
-      <button
+      <ActionButton
         onClick={onVote}
         className={buttonClass}
         {...((loading || !isLogged || alreadyVoted) && { disabled: true })}
@@ -75,7 +76,7 @@ const Button = ({
         ) : (
           buttonContents
         )}
-      </button>
+      </ActionButton>
     </div>
   );
 };
@@ -88,7 +89,7 @@ export const DownvoteButton = ({
   alreadyVoted,
   ...restProps
 }) => (
-  <Button
+  <VoteButton
     {...{
       buttonProps: {
         ...buttonProps,
@@ -115,7 +116,7 @@ export const UpvoteButton = ({
   alreadyVoted = false,
   ...restProps
 }) => (
-  <Button
+  <VoteButton
     {...{
       buttonProps: {
         ...buttonProps,

--- a/frontend/src/pages/ForgotPassword.jsx
+++ b/frontend/src/pages/ForgotPassword.jsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router';
+import { SubmitButton } from '../components/Buttons';
 
 export default function ForgotPassword() {
   return (
@@ -28,9 +29,7 @@ export default function ForgotPassword() {
             </div>
 
             <div className='flex justify-center mt-2'>
-              <button type='submit' className='my-1 animated-button'>
-                Send reset link
-              </button>
+              <SubmitButton>Send reset link</SubmitButton>
             </div>
           </form>
 

--- a/frontend/src/pages/MeEditPage.jsx
+++ b/frontend/src/pages/MeEditPage.jsx
@@ -6,6 +6,7 @@ import { useForm } from 'react-hook-form';
 import { PasswordIcon } from '../components/Icons/PasswordIcon';
 import { UserIcon } from '../components/Icons/UserIcon';
 import Spinny from '../components/Spinny';
+import { SubmitButton } from '../components/Buttons';
 
 const MeEditPage = () => {
   const { isLoading, error, data, response, fetchFromApi, sendAsJson } = useApi(
@@ -216,13 +217,12 @@ const MeEditPage = () => {
               >
                 Back to Profile
               </Link>
-              <button
-                className='my-1 animated-button !text-base !px-5 !py-2 !bg-gray-500 hover:!bg-gray-600'
-                type='submit'
-                {...(isSubmitting && { disabled: 'disabled' })}
+              <SubmitButton
+                additionalClasses='!bg-gray-500 hover:!bg-gray-600'
+                disabled={isSubmitting}
               >
                 Save Changes
-              </button>
+              </SubmitButton>
             </div>
           </form>
         </>

--- a/frontend/src/pages/UserAddPage.jsx
+++ b/frontend/src/pages/UserAddPage.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router';
 import { useUser } from '../hooks/useUser';
 import { useApi } from '../hooks/useApi';
 import Spinny from '../components/Spinny';
+import { SubmitButton } from '../components/Buttons';
 
 const UserAddPage = () => {
   const navigate = useNavigate();
@@ -194,13 +195,12 @@ const UserAddPage = () => {
           </div>
         </div>
 
-        <button
-          type='submit'
-          className='animated-button mt-4 !text-base !px-5 !py-2'
+        <SubmitButton
+          additionalClasses='mt-4 !text-base !px-5 !py-2'
           disabled={isLoading}
         >
           {isLoading ? 'Adding User...' : 'Add User'}
-        </button>
+        </SubmitButton>
       </form>
     </div>
   );

--- a/frontend/src/pages/UserEditPage.jsx
+++ b/frontend/src/pages/UserEditPage.jsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, Link } from 'react-router';
 import { useUser } from '../hooks/useUser';
 import { useApi } from '../hooks/useApi';
 import Spinny from '../components/Spinny';
+import { ActionButton, SubmitButton } from '../components/Buttons';
 
 const UserEditPage = () => {
   const { id } = useParams();
@@ -322,22 +323,16 @@ const UserEditPage = () => {
               <p className='text-error mt-2'>Error: {updateError.message}</p>
             )}
             <div className='flex justify-end gap-4 mt-4'>
-              <button
-                type='button'
+              <ActionButton
                 onClick={cancelUpdate}
-                className='animated-button !text-base !px-5 !py-2 !bg-gray-500 hover:!bg-gray-600'
+                additionalClasses='!bg-gray-500 hover:!bg-gray-600'
                 disabled={isUpdating}
               >
                 Cancel
-              </button>
-              <button
-                type='button'
-                onClick={confirmUpdate}
-                className='animated-button !text-base !px-5 !py-2'
-                disabled={isUpdating}
-              >
+              </ActionButton>
+              <ActionButton onClick={confirmUpdate} disabled={isUpdating}>
                 {isUpdating ? 'Confirming...' : 'Confirm Save'}
-              </button>
+              </ActionButton>
             </div>
           </div>
         )}
@@ -349,13 +344,12 @@ const UserEditPage = () => {
           >
             Back to User Profile
           </Link>
-          <button
-            type='submit'
-            className='animated-button !text-base !px-5 !py-2'
+          <SubmitButton
+            additionalClasses='!text-base !px-5 !py-2'
             disabled={isUpdating || showInlineConfirm || !hasChanges}
           >
             Save Changes
-          </button>
+          </SubmitButton>
         </div>
       </form>
     </div>

--- a/frontend/src/pages/UserPage.jsx
+++ b/frontend/src/pages/UserPage.jsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, Link } from 'react-router';
 import { useUser } from '../hooks/useUser';
 import { useApi } from '../hooks/useApi';
 import Spinny from '../components/Spinny';
+import { SubmitButton } from '../components/Buttons';
 
 const UserPage = () => {
   const { id } = useParams();
@@ -141,13 +142,13 @@ const UserPage = () => {
           >
             View All Ideas
           </Link>
-          <button
+          <SubmitButton
             onClick={handleToggleStatusClick}
             disabled={isUpdating}
             className={confirmButtonClass}
           >
             {isUpdating ? 'Updating Status...' : `${modalAction} Account`}
-          </button>
+          </SubmitButton>
         </div>
       </div>
 
@@ -163,20 +164,20 @@ const UserPage = () => {
             <p className='text-error mb-4'>Error: {updateError.message}</p>
           )}
           <div className='modal-action'>
-            <button
-              className='animated-button !text-base !px-5 !py-2 mr-2'
+            <SubmitButton
+              additionalClasses='mr-2'
               onClick={closeDeactivateModal}
               disabled={isUpdating}
             >
               Cancel
-            </button>
-            <button
+            </SubmitButton>
+            <SubmitButton
               className={confirmButtonClass}
               onClick={confirmToggleStatus}
               disabled={isUpdating}
             >
               {isUpdating ? 'Confirming...' : `Confirm ${modalAction}`}
-            </button>
+            </SubmitButton>
           </div>
         </div>
         <form


### PR DESCRIPTION
- Not very spectacular, but improves reusability. Adds two components wrapping standard button - `SubmitButton` and `ActionButton`.
- `SubmitButton` is expected to be used in form, when submitting.
- `ActionButton` is expected to be used with on click events.
- `animated-button` css style has text size and padding defined, which is not overridden by non-`!` classes. Due to that, to use `animated-button` styling, but change padding and/or text size, the `!` is needed to use. (I also didn't want to touch `styles.css` by myself).