### PR TITLE
fix: detect unused React import

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -26,7 +26,7 @@ export default defineConfig([
       },
     },
     rules: {
-      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'no-unused-vars': ['error', { varsIgnorePattern: '^[_]' }],
       'react/prop-types': 0,
     },
   },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Routes, Route } from 'react-router';
 import { Helmet } from '@dr.pogodin/react-helmet';
 import Header from './components/Header';


### PR DESCRIPTION
- Correctly shows unused `React` import in ESLint.