### PR TITLE
fix: Spinny goes out of the IdeasList component

### DIFF
--- a/frontend/src/components/IdeasList.jsx
+++ b/frontend/src/components/IdeasList.jsx
@@ -76,7 +76,7 @@ const IdeasList = ({
         {error ? (
           `${error}`
         ) : isLoading && entries.length === 0 ? (
-          <div className='spinner-wrapper-container'>
+          <div className='flex items-center justify-center min-h-[100px]'>
             <Spinny />
           </div>
         ) : entries.length === 0 ? (


### PR DESCRIPTION
Now, Spinny stays above the Explore All Ideas to indicate where something is loading correctly.

<!--If pull request closes an issue, write its number in the place of XXXXXX.-->

Closes #226 