### PR TITLE
chore: wrapper to ensure certain userState

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,6 +18,8 @@ import MyIdeasPage from './pages/MyIdeasPage';
 import LogoutPage from './pages/LogoutPage';
 import SearchPage from './pages/SearchPage';
 import UserIdeasPage from './pages/UserIdeasPage';
+import { EnsureAdmin } from './components/EnsureAdmin';
+import { EnsureLogin } from './components/EnsureLogin';
 
 import { IdeaAddPage, IdeaEditPage, IdeaPage, IdeasPage } from './pages/Ideas';
 import './styles.css';
@@ -25,6 +27,7 @@ import './styles.css';
 import ErrorBoundary from './components/ErrorBoundary.jsx';
 import NotFound from './pages/NotFound.jsx';
 
+import { wrapWith } from './utils/wrapWith';
 import { devLog } from './utils/devLogger.jsx';
 import { DevOnly } from './components/DevOnly';
 
@@ -54,25 +57,40 @@ function App() {
             <Route path='forgot-password' element={<ForgotPassword />} />
             <Route path='register' element={<RegisterPage />} />
             <Route path='users'>
-              <Route index element={<UsersPage />} />
-              <Route path=':id' element={<UserPage />} />
-              <Route path=':id/edit' element={<UserEditPage />} />
-              <Route path=':id/ideas' element={<UserIdeasPage />} />
-              <Route path='page/:page' element={<UsersPage />} />
-              <Route path='add' element={<UserAddPage />} />
+              <Route index element={wrapWith(UsersPage, EnsureAdmin)} />
+              <Route path=':id' element={wrapWith(UserPage, EnsureAdmin)} />
+              <Route
+                path=':id/edit'
+                element={wrapWith(UserEditPage, EnsureAdmin)}
+              />
+              <Route
+                path=':id/ideas'
+                element={wrapWith(UserIdeasPage, EnsureAdmin)}
+              />
+              <Route
+                path='page/:page'
+                element={wrapWith(UsersPage, EnsureAdmin)}
+              />
+              <Route path='add' element={wrapWith(UserAddPage, EnsureAdmin)} />
             </Route>
             <Route path='me'>
-              <Route index element={<MePage />} />
-              <Route path='edit' element={<MeEditPage />} />
-              <Route path='ideas' element={<MyIdeasPage />}>
-                <Route path='page/:page' element={<MyIdeasPage />} />
+              <Route index element={wrapWith(MePage, EnsureLogin)} />
+              <Route path='edit' element={wrapWith(MeEditPage, EnsureLogin)} />
+              <Route path='ideas' element={wrapWith(MyIdeasPage, EnsureLogin)}>
+                <Route
+                  path='page/:page'
+                  element={wrapWith(MyIdeasPage, EnsureLogin)}
+                />
               </Route>
             </Route>
             <Route path='logout' element={<LogoutPage />} />
             <Route path='ideas'>
               <Route index element={<IdeasPage headerText='All Ideas' />} />
               <Route path=':ideaId' element={<IdeaPage />} />
-              <Route path=':ideaId/edit' element={<IdeaEditPage />} />
+              <Route
+                path=':ideaId/edit'
+                element={wrapWith(IdeaEditPage, EnsureLogin)}
+              />
               <Route path='add' element={<IdeaAddPage />} />
               <Route
                 path='page/:page'

--- a/frontend/src/components/EnsureAdmin.jsx
+++ b/frontend/src/components/EnsureAdmin.jsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router';
+import { useUser } from '../hooks/useUser';
+import { EnsureLogin } from './EnsureLogin';
+
+export const EnsureAdmin = ({ children }) => (
+  <EnsureLogin>
+    <RequireAdmin>{children}</RequireAdmin>
+  </EnsureLogin>
+);
+
+const RequireAdmin = ({ children }) => {
+  const { isAdmin } = useUser();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isAdmin) {
+      navigate('/');
+    }
+  });
+
+  if (!isAdmin) {
+    return null;
+  }
+
+  return <>{children}</>;
+};
+
+export default EnsureAdmin;

--- a/frontend/src/components/EnsureLogin.jsx
+++ b/frontend/src/components/EnsureLogin.jsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import { useUser } from '../hooks/useUser';
+
+export const EnsureLogin = ({ children }) => {
+  const { isLogged } = useUser();
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isLogged) {
+      navigate(`/login?redirect=${encodeURIComponent(pathname)}`);
+    }
+  });
+
+  if (!isLogged) {
+    return null;
+  }
+
+  return <>{children}</>;
+};
+
+export default EnsureLogin;

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import { Link } from 'react-router';
+import { Link, useLocation, useNavigate } from 'react-router';
 import { useUser } from '../hooks/useUser';
 import LoginForm from './LoginForm';
 import ScrollToHashElement from './ScrollToHashElement';
@@ -10,6 +10,8 @@ import { ActionButton } from './Buttons';
 const Header = () => {
   const dialogRef = useRef();
   const { isLogged, logout, userState, isAdmin } = useUser();
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
 
   const adminLinks = isAdmin
     ? [
@@ -23,7 +25,18 @@ const Header = () => {
     { to: '/me', text: 'My Profile' },
     { to: '/me/ideas', text: 'My Ideas' },
     { to: '/me/edit', text: 'Edit Profile' },
-    { to: '/logout', text: 'Logout', onClick: logout },
+    {
+      to: '/logout',
+      text: 'Logout',
+      onClick: e => {
+        e.preventDefault();
+        if (pathname === '/logout') {
+          logout();
+        } else {
+          navigate('/logout', { state: { logOut: true } });
+        }
+      },
+    },
   ];
 
   return (

--- a/frontend/src/pages/LogoutPage.jsx
+++ b/frontend/src/pages/LogoutPage.jsx
@@ -1,19 +1,52 @@
-import { Link } from 'react-router';
+import { useEffect, useState } from 'react';
+import { Link, useLocation } from 'react-router';
+import { useUser } from '../hooks/useUser';
+import Spinny from '../components/Spinny';
+import { ActionButton } from '../components/Buttons';
 
 export default function LogoutPage() {
+  const { state } = useLocation();
+  const [loggingOut, setLoggingOut] = useState(state?.logOut);
+  const { isLogged, logout } = useUser();
+
+  useEffect(() => {
+    if (loggingOut) {
+      logout();
+      setLoggingOut(false);
+    }
+  }, [loggingOut, logout, setLoggingOut]);
+
+  if (loggingOut) {
+    return <Spinny />;
+  }
+
   return (
     <div className='max-w-md mx-auto mt-16 p-6 bg-[#f4fdf9] rounded-lg shadow-lg border border-[#cdeee3]'>
-      <h1 className='text-2xl font-bold mb-4 text-center text-[#317c67]'>
-        👋 You&apos;re logged out
-      </h1>
-      <p className='mb-6 text-gray-600 text-center'>
-        Thanks for using Idea Forge. You can log in again below.
-      </p>
-      <div className='flex justify-center'>
-        <Link to='/login' className='animated-button !text-base !px-5 !py-2'>
-          ⬅ Back to login
-        </Link>
-      </div>
+      {isLogged ? (
+        <>
+          <h1 className='section-heading'>Log out?</h1>
+          <ActionButton onClick={() => setLoggingOut(true)}>
+            Confirm
+          </ActionButton>
+        </>
+      ) : (
+        <>
+          <h1 className='text-2xl font-bold mb-4 text-center text-[#317c67]'>
+            👋 You&apos;re logged out
+          </h1>
+          <p className='mb-6 text-gray-600 text-center'>
+            Thanks for using Idea Forge. You can log in again below.
+          </p>
+          <div className='flex justify-center'>
+            <Link
+              to='/login'
+              className='animated-button !text-base !px-5 !py-2'
+            >
+              ⬅ Back to login
+            </Link>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/MeEditPage.jsx
+++ b/frontend/src/pages/MeEditPage.jsx
@@ -1,4 +1,3 @@
-import { useUser } from '../hooks/useUser';
 import { Link } from 'react-router';
 import { useEffect, useState } from 'react';
 import { useApi } from '../hooks/useApi';
@@ -16,7 +15,6 @@ const MeEditPage = () => {
       loadingInitially: true,
     }
   );
-  const { isLogged } = useUser();
   const [formSent, setFormSent] = useState(false);
   const [headerUserName, setHeaderUserName] = useState('');
 
@@ -116,16 +114,7 @@ const MeEditPage = () => {
 
   return (
     <div className='section-card min-h-[60vh] flex flex-col items-center'>
-      {!isLogged ? (
-        <>
-          <ErrorElement Element='h1' className='section-heading'>
-            No access
-          </ErrorElement>
-          <p className='text-lg text-gray-600 mb-8 self-center'>
-            You have to be logged in to see this page!
-          </p>
-        </>
-      ) : isLoading ? (
+      {isLoading ? (
         <Spinny />
       ) : (
         <>

--- a/frontend/src/pages/MePage.jsx
+++ b/frontend/src/pages/MePage.jsx
@@ -8,7 +8,7 @@ const MePage = () => {
   const { isLoading, error, data, fetchFromApi } = useApi({
     loadingInitially: true,
   });
-  const { isAdmin, isLogged } = useUser();
+  const { isAdmin } = useUser();
 
   useEffect(() => {
     fetchFromApi(`/me`);
@@ -17,14 +17,7 @@ const MePage = () => {
   return (
     <div className='section-card min-h-[60vh] flex'>
       <div className='card bg-base-100 p-4 w-full text-gray-600 mb-8'>
-        {!isLogged ? (
-          <>
-            <h1 className='section-heading'>No access</h1>
-            <p className='text-lg text-gray-600 mb-8 self-center'>
-              You have to be logged in to see this page!
-            </p>
-          </>
-        ) : isLoading ? (
+        {isLoading ? (
           <Spinny />
         ) : error ? (
           <>`${error}`</>

--- a/frontend/src/pages/UserAddPage.jsx
+++ b/frontend/src/pages/UserAddPage.jsx
@@ -1,15 +1,13 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router';
-import { useUser } from '../hooks/useUser';
 import { useApi } from '../hooks/useApi';
 import Spinny from '../components/Spinny';
 import { SubmitButton } from '../components/Buttons';
 import { FormGroup } from '../components/FormGroup';
-import { DisplayIfError, ErrorElement } from '../components/Errors';
+import { DisplayIfError } from '../components/Errors';
 
 const UserAddPage = () => {
   const navigate = useNavigate();
-  const { isLogged, isAdmin } = useUser();
   const [username, setUsername] = useState('');
   const [name, setName] = useState('');
   const [password, setPassword] = useState('');
@@ -21,16 +19,6 @@ const UserAddPage = () => {
   const { data, isLoading, response, sendFormData } = useApi({
     method: 'POST',
   });
-
-  useEffect(() => {
-    if (!isLogged) {
-      navigate('/login');
-      return;
-    }
-    if (!isAdmin) {
-      navigate('/');
-    }
-  }, [isLogged, isAdmin, navigate]);
 
   useEffect(() => {
     if (response && data) {
@@ -76,19 +64,6 @@ const UserAddPage = () => {
 
   if (isLoading) {
     return <Spinny />;
-  }
-
-  if (!isAdmin) {
-    return (
-      <div className='section-card flex flex-col items-center justify-center min-h-[60vh]'>
-        <ErrorElement Element='h1' className='section-heading'>
-          Access Denied
-        </ErrorElement>
-        <p className='text-lg text-gray-600 mb-8'>
-          You do not have permission to access this page.
-        </p>
-      </div>
-    );
   }
 
   const fields = [

--- a/frontend/src/pages/UserEditPage.jsx
+++ b/frontend/src/pages/UserEditPage.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router';
-import { useUser } from '../hooks/useUser';
 import { useApi } from '../hooks/useApi';
 import Spinny from '../components/Spinny';
 import { ActionButton, SubmitButton } from '../components/Buttons';
@@ -10,7 +9,6 @@ import { DisplayIfError, ErrorElement } from '../components/Errors';
 const UserEditPage = () => {
   const { id } = useParams();
   const navigate = useNavigate();
-  const { isLogged, isAdmin } = useUser();
   const [formData, setFormData] = useState({
     username: '',
     name: '',
@@ -37,19 +35,10 @@ const UserEditPage = () => {
   } = useApi({ method: 'PATCH' });
 
   useEffect(() => {
-    if (!isLogged) {
-      navigate('/login');
-      return;
-    }
-    if (!isAdmin) {
-      navigate('/');
-      return;
-    }
-
     if (id) {
       fetchUser(`/users/${id}`);
     }
-  }, [id, isLogged, isAdmin, navigate, fetchUser]);
+  }, [id, fetchUser]);
 
   useEffect(() => {
     if (fetchedUserData && !fetchError) {

--- a/frontend/src/pages/UserPage.jsx
+++ b/frontend/src/pages/UserPage.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
-import { useParams, useNavigate, Link } from 'react-router';
-import { useUser } from '../hooks/useUser';
+import { useParams, Link } from 'react-router';
 import { useApi } from '../hooks/useApi';
 import Spinny from '../components/Spinny';
 import { SubmitButton } from '../components/Buttons';
@@ -8,8 +7,6 @@ import { DisplayIfError, ErrorElement } from '../components/Errors';
 
 const UserPage = () => {
   const { id } = useParams();
-  const navigate = useNavigate();
-  const { isLogged, isAdmin } = useUser();
   const [userData, setUserData] = useState(null);
   const [showDeactivateModal, setShowDeactivateModal] = useState(false);
   const deactivateModalRef = useRef(null);
@@ -29,19 +26,10 @@ const UserPage = () => {
   } = useApi({ method: 'PATCH' });
 
   useEffect(() => {
-    if (!isLogged) {
-      navigate('/login');
-      return;
-    }
-    if (!isAdmin) {
-      navigate('/');
-      return;
-    }
-
     if (id) {
       fetchUser(`/users/${id}`);
     }
-  }, [id, isLogged, isAdmin, navigate, fetchUser]);
+  }, [id, fetchUser]);
 
   useEffect(() => {
     if (fetchUserData && !fetchUserError) {
@@ -64,7 +52,7 @@ const UserPage = () => {
     if (updateError) {
       console.error('Error updating user status:', updateError);
     }
-  }, [updateUserData, updateError, navigate]);
+  }, [updateUserData, updateError]);
 
   const handleToggleStatusClick = () => {
     setShowDeactivateModal(true);

--- a/frontend/src/pages/UsersPage.jsx
+++ b/frontend/src/pages/UsersPage.jsx
@@ -1,21 +1,20 @@
 import { useEffect, useState, useCallback } from 'react';
-import { useParams, useNavigate } from 'react-router';
-import { useUser } from '../hooks/useUser';
+import { useParams } from 'react-router';
 import { useApi } from '../hooks/useApi';
 import Spinny from '../components/Spinny';
 import { Page, Pagination } from '../components/Pagination';
 import { Link } from 'react-router';
 
 const UsersPage = ({ count = 20 }) => {
-  const { isLogged, isAdmin } = useUser();
-  const navigate = useNavigate();
   const { page = 1 } = useParams();
   const currentPage = Page.fromOneBased(parseInt(page));
 
   const [users, setUsers] = useState([]);
   const [totalPages, setTotalPages] = useState(0);
 
-  const { data, error, isLoading, fetchFromApi } = useApi();
+  const { data, error, isLoading, fetchFromApi } = useApi({
+    loadingInitially: true,
+  });
 
   const getApiUrl = useCallback(
     (page = Page.fromZeroBased(0)) => {
@@ -32,17 +31,8 @@ const UsersPage = ({ count = 20 }) => {
 
   const fetchUrl = getApiUrl(currentPage);
   useEffect(() => {
-    if (!isLogged) {
-      navigate('/login');
-      return;
-    }
-    if (!isAdmin) {
-      navigate('/');
-      return;
-    }
-
     fetchFromApi(fetchUrl);
-  }, [isLogged, isAdmin, navigate, fetchFromApi, fetchUrl]);
+  }, [fetchFromApi, fetchUrl]);
 
   useEffect(() => {
     if (data && !error) {
@@ -55,11 +45,9 @@ const UsersPage = ({ count = 20 }) => {
     }
   }, [data, error, count]);
 
-  if (isLoading && users.length === 0) {
-    return <Spinny />;
-  }
-
-  return (
+  return isLoading && users.length === 0 ? (
+    <Spinny />
+  ) : (
     <div className='section-card flex flex-col items-center min-h-[60vh]'>
       <h1 className='section-heading'>All Users</h1>
       {users.length > 0 ? (

--- a/frontend/src/utils/wrapWith.jsx
+++ b/frontend/src/utils/wrapWith.jsx
@@ -1,0 +1,5 @@
+export const wrapWith = (Element, Wrapper) => (
+  <Wrapper>
+    <Element />
+  </Wrapper>
+);


### PR DESCRIPTION
- `EnsureAdmin` _ensures_ user is admin, before rendering _children_.
- `EnsureLogin` _ensures_ user is logged in, before rendering _children_.
- `EnsureAdmin` uses `EnsureLogin` internally.
- If not logged in user tries to access page requiring being logged in, or being admin, they will be redirected to login, with back-redirect to the accessed page.
- `wrapWith` is little helper to wrap `EnsureAdmin` or `EnsureLogin` around element.
- If logged in user accesses `/logout`, there's button to logout.