### PR TITLE
feat: user ideas

### DIFF
--- a/backend/src/api/routes/users.py
+++ b/backend/src/api/routes/users.py
@@ -14,9 +14,9 @@ from src.dependencies import Db
 from src.models import (
     AdminUserCreate,
     AdminUserEditPatch,
+    AdminUserIdeas,
     Idea,
     IdeaPublic,
-    IdeasPublic,
     LoginData,
     Token,
     User,
@@ -90,16 +90,21 @@ async def get_user(db: Db, id: ObjectId):
     return user
 
 
-@router.get("/{id}/ideas/", response_model=IdeasPublic, dependencies=[AdminUser])
+@router.get("/{id}/ideas/", response_model=AdminUserIdeas, dependencies=[AdminUser])
 async def get_user_ideas(db: Db, id: ObjectId, skip: int = 0, limit: int = 20):
+    user = await db.find_one(User, User.id == id)
+    if user is None:
+        raise HTTPException(404)
+
     ideas = await db.find(
         Idea, Idea.creator_id == id, skip=skip, limit=limit, sort=Idea.name
     )
     count = await db.count(Idea, Idea.creator_id == id)
 
-    return IdeasPublic(
+    return AdminUserIdeas(
         data=[IdeaPublic(**idea.model_dump()) for idea in ideas],
         count=count,
+        username=user.username,
     )
 
 

--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -88,6 +88,10 @@ class IdeasPublic(BaseModel):
     count: int
 
 
+class AdminUserIdeas(IdeasPublic):
+    username: str
+
+
 class IdeaCreate(BaseModel):
     name: NonEmptyMax255CharsString
     description: NonEmptyString

--- a/frontend/src/components/IdeasList.jsx
+++ b/frontend/src/components/IdeasList.jsx
@@ -7,8 +7,9 @@ import { Link } from 'react-router';
 
 const IdeasList = ({
   base = '/ideas/',
-  headerText = 'Vote on Current Ideas',
+  header = 'Vote on Current Ideas',
   noIdeasText = "There's no ideas!",
+  addNewButton = true,
   count,
   sort = null,
   page = Page.fromZeroBased(0),
@@ -16,6 +17,7 @@ const IdeasList = ({
   showExploreButton = false,
 }) => {
   const [showPages, setShowPages] = useState(false);
+  const [headerText, setHeaderText] = useState(null);
   const [totalPages, setTotalPages] = useState(0);
   const [entries, setEntries] = useState([]);
   const { isLoading, error, data, fetchFromApi } = useApi({
@@ -42,10 +44,13 @@ const IdeasList = ({
   }, [fetchFromApi, fetchUrl]);
 
   useEffect(() => {
+    if (data?.data) {
+      setHeaderText(typeof header === 'string' ? header : header(data));
+    }
     if (data?.data?.length > 0) {
       setEntries(data?.data);
     }
-  }, [data]);
+  }, [data, header]);
 
   useEffect(() => {
     if (data?.count > 0) {
@@ -76,7 +81,12 @@ const IdeasList = ({
   return (
     <section className='idea-form-section'>
       <div className='section-card'>
-        <h3 className='section-heading'>{headerText}</h3>
+        {!error &&
+          (headerText ? (
+            <h3 className='section-heading'>{headerText}</h3>
+          ) : (
+            <Spinny />
+          ))}
         {error ? (
           `${error}`
         ) : isLoading && entries.length === 0 ? (
@@ -86,9 +96,11 @@ const IdeasList = ({
         ) : entries.length === 0 ? (
           <div>
             <p>{noIdeasText}</p>
-            <Link to='/ideas/add' className='animated-button'>
-              Add idea
-            </Link>
+            {addNewButton && (
+              <Link to='/ideas/add' className='animated-button'>
+                Add idea
+              </Link>
+            )}
           </div>
         ) : (
           <ul className='idea-list'>

--- a/frontend/src/pages/Ideas/IdeasPage.jsx
+++ b/frontend/src/pages/Ideas/IdeasPage.jsx
@@ -10,7 +10,7 @@ export const IdeasPage = ({ headerText = 'All Ideas' }) => {
         count: 20,
         page: Page.fromOneBased(parseInt(pageOneBased)),
         paginate: true,
-        headerText,
+        header: headerText,
       }}
     />
   );

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -8,7 +8,7 @@ const LandingPage = () => {
       <IdeasList
         count='3'
         sort='trending'
-        headerText='Vote on Current Ideas'
+        header='Vote on Current Ideas'
         showExploreButton={true}
       />
       <IdeaSubmissionForm />

--- a/frontend/src/pages/MyIdeasPage.jsx
+++ b/frontend/src/pages/MyIdeasPage.jsx
@@ -11,7 +11,7 @@ export const MyIdeasPage = ({ headerText = 'My Ideas' }) => {
         count: 20,
         page: Page.fromOneBased(parseInt(page)),
         paginate: true,
-        headerText,
+        header: headerText,
         noIdeasText: "You don't have any ideas added.",
       }}
     />

--- a/frontend/src/pages/UserIdeasPage.jsx
+++ b/frontend/src/pages/UserIdeasPage.jsx
@@ -1,18 +1,22 @@
 import { useParams } from 'react-router';
+import IdeasList from '../components/IdeasList';
+import { Page } from '../components/Pagination';
 
 const UserIdeasPage = () => {
-  const { id } = useParams();
+  const { id, page = 1 } = useParams();
 
   return (
-    <div className='section-card flex flex-col items-center justify-center min-h-[60vh]'>
-      <h1 className='section-heading'>Ideas by User: {id}</h1>
-      <p className='text-lg text-gray-600 mb-8'>
-        This page will list all ideas submitted by user with ID: {id}.
-      </p>
-      <p className='text-sm text-gray-500'>
-        (Functionality to fetch and display user ideas should be added here.)
-      </p>
-    </div>
+    <IdeasList
+      {...{
+        base: `/users/${id}/ideas/`,
+        count: 20,
+        page: Page.fromOneBased(parseInt(page)),
+        paginate: true,
+        header: data => `Ideas from ${data?.username}`,
+        noIdeasText: 'No ideas added.',
+        addNewButton: false,
+      }}
+    />
   );
 };
 


### PR DESCRIPTION
- `/users/:id/ideas/`
- Getting username for the header is a bit hacky, but simply using id was not good.
- `IdeasList`'s `header` accepts either string, or function that should return header text, when passed fetched data.
- There's also prop for disabling displaying button encouraging to add ideas, when no ideas are displayed. It was very strange to see _Add idea_ button when it was somebody's else list of ideas.