### PR TITLE
fix: display pagination, if page number depleted ideas

### DIFF
--- a/frontend/src/components/IdeasList.jsx
+++ b/frontend/src/components/IdeasList.jsx
@@ -93,7 +93,7 @@ const IdeasList = ({
           <div className='flex items-center justify-center min-h-[100px]'>
             <Spinny />
           </div>
-        ) : entries.length === 0 ? (
+        ) : entries.length === 0 && page.displayNumber == 1 ? (
           <div>
             <p>{noIdeasText}</p>
             {addNewButton && (
@@ -109,7 +109,9 @@ const IdeasList = ({
             ))}
           </ul>
         )}
-        {paginate && showPages && entries.length > 0 && <>{pagination}</>}
+        {paginate &&
+          showPages &&
+          (entries.length > 0 || page.displayNumber > 1) && <>{pagination}</>}
 
         {showExploreButton && (
           <div style={{ textAlign: 'center', marginTop: 'var(--spacing-md)' }}>


### PR DESCRIPTION
- Ie. there were `2` pages of ideas. If one would manually visit url for page `3` or higher, there would be _no ideas text_ displayed, and no pagination.
- Now there's no _no ideas text_, and pagination is displayed.