### PR TITLE
fix: second call not executed if first raises error

### DIFF
--- a/backend/src/api/ideas.py
+++ b/backend/src/api/ideas.py
@@ -117,6 +117,7 @@ async def vote(
 
     with suppress(ValueError):
         getattr(user, attributes.user_remove_from).remove(idea.id)
+    with suppress(ValueError):
         getattr(idea, attributes.idea_remove_from).remove(user.id)
 
     getattr(user, attributes.user_add_to).append(idea.id)


### PR DESCRIPTION
- Because both needs to be always executed, there's need for separate, two `suppress` usages.