### PR TITLE
chore: real_db pytest fixture

### DIFF
--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     csrf_secret_key: str
     home_location: str
     mongodb_uri: str
+    mongodb_test_uri: str
     secret_key: str
 
     model_config = SettingsConfigDict(

--- a/backend/tests/api/test_ideas.py
+++ b/backend/tests/api/test_ideas.py
@@ -144,13 +144,13 @@ VOTE_CALL_TEST_CASES = (
     VOTE_CASES,
 )
 async def test_vote_modifies_user_and_idea_objects(
-    db, cleanup_votes, user, idea, user_vote, setup
+    fake_db, cleanup_votes, user, idea, user_vote, setup
 ):
     with cleanup_votes(user, idea):
         setup(user, idea)
         new_vote = user_vote(idea_id=idea.id)
 
-        result = await vote(db, user, idea, new_vote)
+        result = await vote(fake_db, user, idea, new_vote)
         check_vote(user, result, new_vote)
 
 
@@ -160,17 +160,17 @@ async def test_vote_modifies_user_and_idea_objects(
     VOTE_CALL_TEST_CASES,
 )
 async def test_vote_calls_db_save(
-    db, cleanup_votes, user, idea, user_vote, setup, should_call
+    fake_db, cleanup_votes, user, idea, user_vote, setup, should_call
 ):
     with cleanup_votes(user, idea):
         setup(user, idea)
         new_vote = user_vote(idea_id=idea.id)
 
-        await vote(db, user, idea, new_vote)
+        await vote(fake_db, user, idea, new_vote)
 
         if should_call:
-            assert db.save.await_count == 2
-            db.save.assert_any_await(user)
-            db.save.assert_any_await(idea)
+            assert fake_db.save.await_count == 2
+            fake_db.save.assert_any_await(user)
+            fake_db.save.assert_any_await(idea)
         else:
-            db.save.assert_not_awaited()
+            fake_db.save.assert_not_awaited()

--- a/backend/tests/api/test_util.py
+++ b/backend/tests/api/test_util.py
@@ -34,8 +34,8 @@ from ..data_sample import ideas, users
         ],
     ],
 )
-async def test_find_one_or_404_valid_ids(db, model, id, expected):
-    result = await find_one_or_404(db, model, id)
+async def test_find_one_or_404_valid_ids(fake_db, model, id, expected):
+    result = await find_one_or_404(fake_db, model, id)
     assert result == expected
 
 
@@ -49,8 +49,8 @@ async def test_find_one_or_404_valid_ids(db, model, id, expected):
         [User, ideas["idea1"].id],
     ],
 )
-async def test_find_one_or_404_invalid_ids(db, model, id):
+async def test_find_one_or_404_invalid_ids(fake_db, model, id):
     with pytest.raises(HTTPException) as exception:
-        await find_one_or_404(db, model, id)
+        await find_one_or_404(fake_db, model, id)
     assert exception.value.status_code == 404
     assert exception.value.detail == "Not found"

--- a/backend/tests/data_sample.py
+++ b/backend/tests/data_sample.py
@@ -5,7 +5,7 @@ from src.models import Idea, User
 
 user1 = User.model_validate(
     {
-        "username": "user",
+        "username": "test_user",
         "name": "name of user",
         "is_active": True,
         "is_admin": False,
@@ -16,7 +16,7 @@ user1 = User.model_validate(
 )
 user_admin = User.model_validate(
     {
-        "username": "adminUser",
+        "username": "test_adminUser",
         "name": "True Admin",
         "is_active": True,
         "is_admin": True,
@@ -27,7 +27,7 @@ user_admin = User.model_validate(
 )
 user_disabled = User.model_validate(
     {
-        "username": "disabled",
+        "username": "test_disabled",
         "name": "Disabled user",
         "is_active": False,
         "is_admin": False,
@@ -38,7 +38,7 @@ user_disabled = User.model_validate(
 )
 user_disabled_with_outdated_hash = User.model_validate(
     {
-        "username": "old_one",
+        "username": "test_old_one",
         "name": "user with bcrypt hash",
         "is_active": False,
         "is_admin": False,
@@ -52,7 +52,7 @@ user_disabled_with_outdated_hash = User.model_validate(
 
 idea1 = Idea.model_validate(
     {
-        "name": "Sample idea",
+        "name": "Test_Sample idea",
         "description": "Description of the sample idea, not very long.",
         "upvoted_by": [ObjectId() for _ in range(10)],
         "downvoted_by": [ObjectId() for _ in range(2)],
@@ -61,7 +61,7 @@ idea1 = Idea.model_validate(
 )
 idea2 = Idea.model_validate(
     {
-        "name": "Different idea",
+        "name": "Test_Different idea",
         "description": "Different description of the different idea, a bit longer, but still not very long.",  # noqa: E501
         "upvoted_by": [ObjectId() for _ in range(10)],
         "downvoted_by": [ObjectId() for _ in range(2)],

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -14,6 +14,7 @@ def env_variables():
         "csrf_secret_key": "csrf-secret-key",
         "home_location": "http://different.random.com:8000",
         "mongodb_uri": "mongodb://completely.different.com/name?directConnection=true",
+        "mongodb_test_uri": "mongodb://completely.very.different.com/dbname?directConnection=true",
         "secret_key": "secret-key-for-jwt",
     }
 

--- a/sample.env
+++ b/sample.env
@@ -1,4 +1,5 @@
 MONGODB_URI=mongodb://127.0.0.1:27017/ideaforge?directConnection=true
+MONGODB_TEST_URI=mongodb://127.0.0.1:27017/ideaforge?directConnection=true
 
 HOME_LOCATION=http://localhost:5173
 VITE_HOME_LOCATION=http://localhost:5173


### PR DESCRIPTION
- For tests relying on real mongodb.
- For development `MONGODB_TEST_URI` env variable can be the same as the non-test. Fixture is supposed to clean-up data that's added.
- To easily differentiate, and avoid conflicts `test_` and `Test_` prefixes were added.