### PR TITLE
chore: pytest integration marker

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1,4 +1,4 @@
-name: Test backend
+name: Test backend (unit test)
 
 on:
   push:
@@ -11,7 +11,7 @@ on:
 
 
 jobs:
-  test-backend:
+  test-backend-unit-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,4 +25,4 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --all-extras --dev --directory ./backend
       - name: Run tests
-        run: uv run --directory ./backend pytest
+        run: uv run --directory ./backend pytest -m "not integration"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -34,3 +34,8 @@ warn_return_any = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 warn_unreachable = true
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: marks integration test requiring ie. real database, can be run with `pytest -m integration`",
+]


### PR DESCRIPTION
- Current idea is to run unit tests with `pytest -m "not integration"`, and integration tests with `pytest -m integration`.