### PR TITLE
fix: rogue `hashed_password` updates

### DIFF
--- a/backend/src/api/routes/users.py
+++ b/backend/src/api/routes/users.py
@@ -14,6 +14,7 @@ from src.dependencies import Db
 from src.models import (
     AdminUserCreate,
     AdminUserEditPatch,
+    AdminUserEditPatchInput,
     AdminUserIdeas,
     LoginData,
     Token,
@@ -98,9 +99,12 @@ async def get_ideas(db: Db, user: UserFromPath, pagination: PaginationParams):
 
 
 @router.patch("/{id}", response_model=UserMe, dependencies=[AdminUser])
-async def update_user(db: Db, user: UserFromPath, update_data: AdminUserEditPatch):
-    if update_data.new_password is not None:
-        update_data.hashed_password = get_password_hash(update_data.new_password)
-    user.model_update(update_data, exclude={"old_password, new_password"})
+async def update_user(db: Db, user: UserFromPath, input_data: AdminUserEditPatchInput):
+    update_data = AdminUserEditPatch(
+        **{key: value for key, value in input_data.model_dump().items() if value}
+    )
+    if input_data.new_password:
+        update_data.hashed_password = get_password_hash(input_data.new_password)
+    user.model_update(update_data)
     await db.save(user)
     return user

--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -52,16 +52,28 @@ class UserRegister(BaseModel):
     password: PasswordString
 
 
-class UserEditPatch(BaseModel):
+class UserEditPatchInput(BaseModel):
     name: Max255CharsString | None = None
     old_password: EmptyString | PasswordString | None = None
     new_password: EmptyString | PasswordString | None = None
+
+
+class UserEditPatch(BaseModel):
+    name: Max255CharsString | None = None
     hashed_password: str | None = None
 
 
-class AdminUserEditPatch(UserEditPatch):
+class AdminUserEditFields(BaseModel):
     is_active: bool | None = None
     is_admin: bool | None = None
+
+
+class AdminUserEditPatchInput(UserEditPatchInput, AdminUserEditFields):
+    pass
+
+
+class AdminUserEditPatch(UserEditPatch, AdminUserEditFields):
+    pass
 
 
 class AdminUserCreate(UserRegister):

--- a/backend/tests/api/routes/test_me.py
+++ b/backend/tests/api/routes/test_me.py
@@ -165,9 +165,10 @@ async def test_PATCH_me_changes_name_with_password_when_old_password_is_correct(
         {},
         {"new_password": "", "old_password": ""},
         {"new_password": "", "old_password": PASSWORD},
+        {"hashed_password": "changed"},
     ],
 )
-async def test_PATCH_me_does_not_update_empty_data(
+async def test_PATCH_me_does_not_update_empty_or_additional_data(
     real_db, user_with_client, new_name_data, new_password_data
 ):
     user, async_client = user_with_client


### PR DESCRIPTION
- Moves `hashed_password` out of the user input model. It was being updated if request contained `hashed_password`.