### PR TITLE
fix: field requiring non-empty if included

### DIFF
--- a/backend/src/api/routes/me.py
+++ b/backend/src/api/routes/me.py
@@ -22,16 +22,14 @@ async def patch_me(
     current_user: Annotated[User, LoggedInUser],
     update_input: UserEditPatchInput,
 ):
-    update_data = UserEditPatch(
-        **{key: value for key, value in update_input.model_dump().items() if value}
-    )
+    update_data = UserEditPatch(**update_input.model_dump())
     if update_input.new_password:
         if not update_input.old_password or not verify_password(
             update_input.old_password, current_user.hashed_password
         ):
             raise HTTPException(status_code=403, detail="Invalid password")
         update_data.hashed_password = get_password_hash(update_input.new_password)
-    current_user.model_update(update_data)
+    current_user.model_update(update_data, exclude_none=True)
     await db.save(current_user)
     return current_user
 

--- a/backend/src/api/routes/users.py
+++ b/backend/src/api/routes/users.py
@@ -100,11 +100,9 @@ async def get_ideas(db: Db, user: UserFromPath, pagination: PaginationParams):
 
 @router.patch("/{id}", response_model=UserMe, dependencies=[AdminUser])
 async def update_user(db: Db, user: UserFromPath, input_data: AdminUserEditPatchInput):
-    update_data = AdminUserEditPatch(
-        **{key: value for key, value in input_data.model_dump().items() if value}
-    )
+    update_data = AdminUserEditPatch(**input_data.model_dump())
     if input_data.new_password:
         update_data.hashed_password = get_password_hash(input_data.new_password)
-    user.model_update(update_data)
+    user.model_update(update_data, exclude_none=True)
     await db.save(user)
     return user

--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -53,26 +53,31 @@ class UserRegister(BaseModel):
 
 
 class UserEditPatchInput(BaseModel):
-    name: Max255CharsString | None = None
+    name: NonEmptyMax255CharsString | None = None
     old_password: EmptyString | PasswordString | None = None
     new_password: EmptyString | PasswordString | None = None
 
 
 class UserEditPatch(BaseModel):
-    name: Max255CharsString | None = None
+    name: NonEmptyMax255CharsString | None
     hashed_password: str | None = None
 
 
-class AdminUserEditFields(BaseModel):
+class AdminUserEditInputFields(BaseModel):
     is_active: bool | None = None
     is_admin: bool | None = None
 
 
-class AdminUserEditPatchInput(UserEditPatchInput, AdminUserEditFields):
+class AdminUserEditPatchFields(BaseModel):
+    is_active: bool | None
+    is_admin: bool | None
+
+
+class AdminUserEditPatchInput(UserEditPatchInput, AdminUserEditInputFields):
     pass
 
 
-class AdminUserEditPatch(UserEditPatch, AdminUserEditFields):
+class AdminUserEditPatch(UserEditPatch, AdminUserEditPatchFields):
     pass
 
 


### PR DESCRIPTION
- This might sound a bit mouthful. There might be somewhere better terms for it, I'm not sure.
- `name` is optional in a sense - it doesn't need to be included in the request. In such case it will have default `None` value for a while and then it will be ignored when updating.
- However if `name` is included, but it's empty (string: `''`), that's an error.
- On the other hand `new_password` is optional - doesn't need to be included in the request. But it also can be included and empty - `''`, in both cases password should not be updated.
- Very possible it will be further changed to make it