### PR TITLE
chore: update defaults in models

### DIFF
--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -42,7 +42,7 @@ class UsersAdmin(BaseModel):
 
 class UserPublic(BaseModel):
     id: ObjectId
-    name: str = Field(max_length=255)
+    name: str
 
 
 class UsersPublic(BaseModel):
@@ -101,8 +101,8 @@ class IdeaPublic(BaseModel):
     id: ObjectId
     name: str
     description: str
-    upvoted_by: list[ObjectId] = []
-    downvoted_by: list[ObjectId] = []
+    upvoted_by: list[ObjectId]
+    downvoted_by: list[ObjectId]
     creator_id: ObjectId
 
 
@@ -121,8 +121,8 @@ class IdeaCreate(BaseModel):
 
 
 class IdeaEditPatch(BaseModel):
-    name: NonEmptyMax255CharsString | None = Field(max_length=255)
-    description: StrippedString | None
+    name: NonEmptyMax255CharsString | None = None
+    description: NonEmptyString | None = None
 
 
 class IdeaUpvote(BaseModel):


### PR DESCRIPTION
- `UserPublic`, `IdeaPublic` they work with already created `User` and `Idea` objects, which must have fields that were having default values in changed models.
- `IdeaEditPatch`
  - `name` - length constraint is enforced by type. Default `None` allows updating fields in the model individually. 
  - `description` - unifying str type.