### PR TITLE
chore: enable ruff flake8-pytest-style rules for pytest

### DIFF
--- a/backend/ruff.toml
+++ b/backend/ruff.toml
@@ -47,6 +47,7 @@ select = [
     "C4",  # flake8-comprehensions
     "UP",  # pyupgrade
     "ARG001", # unused arguments in functions
+    "PT", # flake8-pytest-style
 ]
 ignore = []
 

--- a/backend/tests/api/routes/test_ideas.py
+++ b/backend/tests/api/routes/test_ideas.py
@@ -91,7 +91,7 @@ INVALID_IDEA_ID_CASES = [
 @pytest.mark.integration
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["setup"],
+    "setup",
     UPVOTE_CASES,
 )
 @pytest.mark.parametrize(
@@ -134,7 +134,7 @@ async def test_PUT_upvote_idea_returns_upvoted_idea(
 @pytest.mark.integration
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["setup"],
+    "setup",
     UPVOTE_CASES,
 )
 @pytest.mark.parametrize(
@@ -172,7 +172,7 @@ async def test_PUT_upvote_idea_updates_idea_in_db(
 @pytest.mark.integration
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["setup"],
+    "setup",
     UPVOTE_CASES,
 )
 @pytest.mark.parametrize(
@@ -210,7 +210,7 @@ async def test_PUT_upvote_idea_updates_user_in_db(
 @pytest.mark.integration
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["setup"],
+    "setup",
     UPVOTE_CASES,
 )
 @pytest.mark.parametrize(
@@ -266,7 +266,7 @@ async def test_PUT_upvote_idea_returns_404_when_idea_id_does_not_exist(
 @pytest.mark.integration
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["setup"],
+    "setup",
     DOWNVOTE_CASES,
 )
 @pytest.mark.parametrize(
@@ -306,7 +306,7 @@ async def test_PUT_downvote_idea_returns_downvoted_idea(
 @pytest.mark.integration
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["setup"],
+    "setup",
     DOWNVOTE_CASES,
 )
 @pytest.mark.parametrize(
@@ -344,7 +344,7 @@ async def test_PUT_downvote_idea_updates_idea_in_db(
 @pytest.mark.integration
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["setup"],
+    "setup",
     DOWNVOTE_CASES,
 )
 @pytest.mark.parametrize(
@@ -385,7 +385,7 @@ async def test_PUT_downvote_idea_updates_user_in_db(
 @pytest.mark.integration
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["setup"],
+    "setup",
     DOWNVOTE_CASES,
 )
 @pytest.mark.parametrize(

--- a/backend/tests/api/routes/test_users.py
+++ b/backend/tests/api/routes/test_users.py
@@ -369,7 +369,7 @@ async def test_GET_users_id_does_not_return_hashed_password(
 @pytest.mark.integration
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["bad_id", "status_code"],
+    ("bad_id", "status_code"),
     [
         pytest.param("notobjectid", 422, id="not valid object id"),
         pytest.param("/", 404, id="empty id"),
@@ -400,7 +400,7 @@ async def test_GET_users_id_returns_404_when_id_does_not_exist(
 @pytest.mark.integration
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["bad_id", "status_code"],
+    ("bad_id", "status_code"),
     [
         pytest.param("notobjectid", 422, id="not valid object id"),
         pytest.param("/", 404, id="empty id"),
@@ -510,7 +510,7 @@ async def test_GET_users_id_ideas_returns_user_ideas_in_data_ordered_by_name(
 @pytest.mark.integration
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["patch_data", "user"],
+    ("patch_data", "user"),
     PATCH_DATA_WITH_INITIAL_USER_OPTIONS,
     indirect=["user"],
 )
@@ -529,7 +529,7 @@ async def test_PATCH_users_id_returns_updated_user_after_patch(
 @pytest.mark.integration
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["patch_data", "user"],
+    ("patch_data", "user"),
     PATCH_DATA_WITH_INITIAL_USER_OPTIONS,
     indirect=["user"],
 )

--- a/backend/tests/api/test_ideas.py
+++ b/backend/tests/api/test_ideas.py
@@ -158,7 +158,7 @@ VOTE_CALL_TEST_CASES = (
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["user", "idea", "user_vote", "setup"],
+    ("user", "idea", "user_vote", "setup"),
     VOTE_CASES,
 )
 async def test_vote_modifies_user_and_idea_objects(
@@ -174,7 +174,7 @@ async def test_vote_modifies_user_and_idea_objects(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["user", "idea", "user_vote", "setup", "should_call"],
+    ("user", "idea", "user_vote", "setup", "should_call"),
     VOTE_CALL_TEST_CASES,
 )
 async def test_vote_calls_db_save(
@@ -226,14 +226,14 @@ async def test_count_ideas_returns_correct_number_of_ideas_after_adding_ideas(
 @pytest.mark.integration
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["vote_for", "voted_for", "idea_attr"],
+    ("vote_for", "voted_for", "idea_attr"),
     [
         pytest.param("downvote", "downvotes", "downvoted_by", id="downvote"),
         pytest.param("upvote", "upvotes", "upvoted_by", id="upvote"),
     ],
 )
 @pytest.mark.parametrize(
-    ["user_with_ideas", "votes_count"],
+    ("user_with_ideas", "votes_count"),
     [(30, count) for count in [5, 10, 15, 20, 22]],
     indirect=["user_with_ideas"],
 )
@@ -259,14 +259,14 @@ async def test_get_voted_ideas_returns_correct_ideas_and_correct_count_of_them(
 @pytest.mark.integration
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["vote_for", "voted_for"],
+    ("vote_for", "voted_for"),
     [
         pytest.param("downvote", "downvotes", id="downvote"),
         pytest.param("upvote", "upvotes", id="upvote"),
     ],
 )
 @pytest.mark.parametrize(
-    ["user_with_ideas", "votes_count"],
+    ("user_with_ideas", "votes_count"),
     [(30, count) for count in [5, 10, 15, 20, 22]],
     indirect=["user_with_ideas"],
 )
@@ -325,7 +325,7 @@ async def test_get_user_ideas_returns_ideas_sorted_by_name(
 @pytest.mark.integration
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["sort", "func_to_comparator"],
+    ("sort", "func_to_comparator"),
     [("trending", lambda idea: -len(idea.upvoted_by)), (None, lambda idea: idea.name)],
 )
 @pytest.mark.parametrize("ideas_with_fake_votes", [15], indirect=True)

--- a/backend/tests/api/test_routes.py
+++ b/backend/tests/api/test_routes.py
@@ -18,7 +18,7 @@ from ..data_sample import idea1, user1, user_admin_disabled, user_disabled
     indirect=True,
 )
 @pytest.mark.parametrize(
-    ["sample_user_token", "expected_detail", "expected_status_code"],
+    ("sample_user_token", "expected_detail", "expected_status_code"),
     [
         pytest.param("", "Not authenticated", 401, id="not logged in"),
         pytest.param(user1.id, "Not enough permissions", 403, id="logged in user"),
@@ -63,7 +63,7 @@ async def test_admin_only_route_returns_error_if_not_admin_or_disabled_admin(
     indirect=True,
 )
 @pytest.mark.parametrize(
-    ["sample_user_token", "expected_detail", "expected_status_code"],
+    ("sample_user_token", "expected_detail", "expected_status_code"),
     [
         pytest.param("", "Not authenticated", 401, id="not logged in"),
         pytest.param(user_admin_disabled.id, "Inactive user", 400, id="disabled admin"),

--- a/backend/tests/api/test_util.py
+++ b/backend/tests/api/test_util.py
@@ -10,28 +10,28 @@ from ..data_sample import ideas, users
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["model", "id", "expected"],
+    ("model", "id", "expected"),
     [
-        [
+        (
             Idea,
             ideas["idea1"].id,
             ideas["idea1"],
-        ],
-        [
+        ),
+        (
             Idea,
             ideas["idea2"].id,
             ideas["idea2"],
-        ],
-        [
+        ),
+        (
             User,
             users["user1"].id,
             users["user1"],
-        ],
-        [
+        ),
+        (
             User,
             users["user2"].id,
             users["user2"],
-        ],
+        ),
     ],
 )
 async def test_find_one_or_404_valid_ids(fake_db, model, id, expected):
@@ -41,12 +41,12 @@ async def test_find_one_or_404_valid_ids(fake_db, model, id, expected):
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["model", "id"],
+    ("model", "id"),
     [
-        [Idea, ObjectId()],
-        [Idea, users["user1"].id],
-        [User, ObjectId()],
-        [User, ideas["idea1"].id],
+        (Idea, ObjectId()),
+        (Idea, users["user1"].id),
+        (User, ObjectId()),
+        (User, ideas["idea1"].id),
     ],
 )
 async def test_find_one_or_404_invalid_ids(fake_db, model, id):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -78,7 +78,7 @@ def jwt_secret_key():
     return "test-secret-key"
 
 
-@pytest.fixture()
+@pytest.fixture
 def sample_user_token(jwt_secret_key, request):
     user_id = str(request.param)
     if not user_id:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -109,7 +109,7 @@ INVALID_DATA_TOKENS = [
 
 
 @pytest.mark.parametrize(
-    ["plain_password", "hashed_password", "expected"],
+    ("plain_password", "hashed_password", "expected"),
     [
         pytest.param(
             "password",
@@ -154,7 +154,7 @@ def test_verify_password(plain_password, hashed_password, expected):
 
 
 @pytest.mark.parametrize(
-    ["plain_password", "hashed_password", "expected", "expected_rehash_type"],
+    ("plain_password", "hashed_password", "expected", "expected_rehash_type"),
     [
         pytest.param(
             "password",
@@ -207,7 +207,7 @@ def test_verify_and_update_password(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["user", "plain_password", "expected"],
+    ("user", "plain_password", "expected"),
     [
         pytest.param(
             user1.username,
@@ -290,7 +290,7 @@ def test_create_access_token_encoded_token_has_correct_data(patch_jwt_secret_key
 
 
 @pytest.mark.parametrize(
-    ["expiration_delta"],
+    "expiration_delta",
     [
         pytest.param(
             ACCESS_TOKEN_DELTA,
@@ -370,7 +370,7 @@ def test_set_refresh_token_cookie_calls_set_cookie_method(jwt_fixtures):
 
 
 @pytest.mark.parametrize(
-    ["sample_user_token", "user_id"],
+    ("sample_user_token", "user_id"),
     [(user.id, str(user.id)) for user in users.values()],
     indirect=["sample_user_token"],
 )
@@ -433,7 +433,7 @@ async def test_get_current_user_raises_when_token_doesnt_contain_id_of_existing_
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["sample_user_token", "expected"],
+    ("sample_user_token", "expected"),
     ((user.id, user) for user in users.values()),
     indirect=["sample_user_token"],
 )
@@ -447,7 +447,7 @@ async def test_get_current_user_returns_existing_user_for_valid_token(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["sample_user_token", "user_id"],
+    ("sample_user_token", "user_id"),
     [(user.id, str(user.id)) for user in users.values()],
     indirect=["sample_user_token"],
 )
@@ -488,7 +488,7 @@ async def test_refresh_token_raises_when_token_is_invalid(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ["encoded_token"],
+    "encoded_token",
     INVALID_DATA_TOKENS
     + [
         pytest.param(

--- a/backend/tests/test_csrf.py
+++ b/backend/tests/test_csrf.py
@@ -54,7 +54,7 @@ async def test_verify_csrf_returns_True_when_safe_method_is_used(
     ],
 )
 @pytest.mark.parametrize(
-    ["headers", "raised_exception", "error"],
+    ("headers", "raised_exception", "error"),
     [
         pytest.param(
             [], MissingTokenError, "Missing Cookie", id="without cookie and token"


### PR DESCRIPTION
- Just a bit of consistent style enforcing by ruff for pytest tests.