### PR TITLE
chore: pytest config - fail on passing xfail

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -39,3 +39,4 @@ warn_unreachable = true
 markers = [
     "integration: marks integration test requiring ie. real database, can be run with `pytest -m integration`",
 ]
+xfail_strict = true


### PR DESCRIPTION
- Test will fail when test marked with `xfail` (expected failing) will suddenly start passing.