### PR TITLE
feat: idea datetime

### DIFF
--- a/backend/src/api/ideas.py
+++ b/backend/src/api/ideas.py
@@ -22,13 +22,7 @@ async def get_ideas_by_upvotes(db: Db, skip: int, limit: int, ascending=False):
     collection = db.engine.get_collection(Idea)
     aggregates: Sequence[Mapping[str, Any]] = [
         {
-            "$project": {
-                "_id": 1,
-                "name": 1,
-                "description": 1,
-                "upvoted_by": 1,
-                "downvoted_by": 1,
-                "creator_id": 1,
+            "$addFields": {
                 "upvotes": {"$size": "$upvoted_by"},
             }
         },

--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -1,8 +1,9 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Annotated
 
 from odmantic import Field, Model, ObjectId
 from pydantic import (
+    AfterValidator,
     BaseModel,
     StringConstraints,
     computed_field,
@@ -20,6 +21,20 @@ NonEmptyMax255CharsString = Annotated[
     str, StringConstraints(max_length=255, min_length=1, strip_whitespace=True)
 ]
 PasswordString = Annotated[str, StringConstraints(min_length=8, strip_whitespace=True)]
+
+
+def to_utc(input: datetime) -> datetime:
+    if input.tzinfo is None:
+        return input.replace(tzinfo=UTC)
+    elif input.tzinfo is not UTC:
+        return input.astimezone(UTC)
+    return input
+
+
+DateTimeUTC = Annotated[
+    datetime,
+    AfterValidator(to_utc),
+]
 
 
 class WithModifiedAtAutoUpdate(BaseModel):

--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -123,6 +123,8 @@ class AdminUserCreate(UserRegister):
 
 
 class Idea(Model):
+    created_at: DateTimeUTC = Field(default_factory=datetime_now, index=True)
+    modified_at: DateTimeUTC = Field(default_factory=datetime_now, index=True)
     name: str
     description: str
     upvoted_by: list[ObjectId] = []
@@ -132,6 +134,7 @@ class Idea(Model):
 
 class IdeaPublic(BaseModel):
     id: ObjectId
+    created_at: DateTimeUTC
     name: str
     description: str
     upvoted_by: list[ObjectId]

--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -22,6 +22,13 @@ NonEmptyMax255CharsString = Annotated[
 PasswordString = Annotated[str, StringConstraints(min_length=8, strip_whitespace=True)]
 
 
+class WithModifiedAtAutoUpdate(BaseModel):
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def modified_at(self) -> datetime:
+        return datetime_now()
+
+
 class User(Model):
     created_at: datetime = Field(default_factory=datetime_now)
     modified_at: datetime = Field(default_factory=datetime_now)
@@ -73,14 +80,9 @@ class UserEditPatchInput(BaseModel):
     new_password: EmptyString | PasswordString | None = None
 
 
-class UserEditPatch(BaseModel):
+class UserEditPatch(WithModifiedAtAutoUpdate):
     name: NonEmptyMax255CharsString | None
     hashed_password: str | None = None
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def modified_at(self) -> datetime:
-        return datetime_now()
 
 
 class AdminUserEditInputFields(BaseModel):
@@ -136,7 +138,7 @@ class IdeaCreate(BaseModel):
     description: NonEmptyString
 
 
-class IdeaEditPatch(BaseModel):
+class IdeaEditPatch(WithModifiedAtAutoUpdate):
     name: NonEmptyMax255CharsString | None = None
     description: NonEmptyString | None = None
 

--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -45,8 +45,8 @@ class WithModifiedAtAutoUpdate(BaseModel):
 
 
 class User(Model):
-    created_at: datetime = Field(default_factory=datetime_now)
-    modified_at: datetime = Field(default_factory=datetime_now)
+    created_at: DateTimeUTC = Field(default_factory=datetime_now)
+    modified_at: DateTimeUTC = Field(default_factory=datetime_now)
     username: str = Field(unique=True)
     name: str = Field(max_length=255)
     hashed_password: str
@@ -58,8 +58,8 @@ class User(Model):
 
 class UserMe(BaseModel):
     id: ObjectId
-    created_at: datetime
-    modified_at: datetime
+    created_at: DateTimeUTC
+    modified_at: DateTimeUTC
     username: str
     name: str
     is_active: bool

--- a/backend/tests/api/routes/test_me.py
+++ b/backend/tests/api/routes/test_me.py
@@ -1,5 +1,5 @@
 import random
-from datetime import UTC, datetime
+from datetime import datetime
 
 import pytest
 from httpx import AsyncClient
@@ -76,7 +76,7 @@ async def test_GET_me_returns_expected_user_info_for_logged_in_active(
         if key in {"hashed_password", "id"}:
             continue
         elif key in {"created_at", "modified_at"}:
-            assert datetime.fromisoformat(data.get(key)).replace(tzinfo=UTC) == value
+            assert datetime.fromisoformat(data.get(key)) == value
         else:
             assert data.get(key) == value
     assert data["id"] == str(user.id)
@@ -138,7 +138,7 @@ async def test_PATCH_me_changes_modified_at(
 
     assert updated_user is not None
     assert now > datetime.fromisoformat(data["modified_at"]) > user.modified_at
-    assert now > updated_user.modified_at.replace(tzinfo=UTC) > user.modified_at
+    assert now > updated_user.modified_at > user.modified_at
 
 
 @pytest.mark.integration

--- a/backend/tests/api/routes/test_users.py
+++ b/backend/tests/api/routes/test_users.py
@@ -1,5 +1,5 @@
 from contextlib import asynccontextmanager
-from datetime import UTC, datetime
+from datetime import datetime
 
 import pytest
 from httpx import AsyncClient
@@ -529,6 +529,8 @@ async def test_PATCH_users_id_returns_updated_user_after_patch(
     assert data["is_active"] == patch_data.get("is_active", user.is_active)
     assert data["is_admin"] == patch_data.get("is_admin", user.is_admin)
 
+    assert datetime.fromisoformat(data["created_at"]) == user.created_at
+
 
 @pytest.mark.integration
 @pytest.mark.anyio
@@ -556,6 +558,8 @@ async def test_PATCH_users_id_saves_changes_in_db(
     assert updated_user.upvotes == user.upvotes
     assert updated_user.downvotes == user.downvotes
 
+    assert updated_user.created_at == user.created_at
+
 
 @pytest.mark.integration
 @pytest.mark.anyio
@@ -577,7 +581,7 @@ async def test_PATCH_users_id_changes_modified_at(
 
     assert updated_user is not None
     assert now > datetime.fromisoformat(data["modified_at"]) > user.modified_at
-    assert now > updated_user.modified_at.replace(tzinfo=UTC) > user.modified_at
+    assert now > updated_user.modified_at > user.modified_at
 
 
 @pytest.mark.integration


### PR DESCRIPTION
- Datetimes for Idea
- Couple adjustments to datetime keeping. Currently any datetime that has no timezone info is assumed to be in the utc. This isn't perfect, but it's required since datetime from the database will not have timezone info.