### PR TITLE
chore: replace asserts with `all` with `for` loop

### DIFF
--- a/backend/tests/api/test_ideas.py
+++ b/backend/tests/api/test_ideas.py
@@ -21,9 +21,8 @@ from ..util import setup_ideas, setup_votes
 
 def assert_in_order(items, ascending=True):
     compare = operator.le if ascending else operator.ge
-    assert all(
-        compare(items[prev_index], item) for prev_index, item in enumerate(items[1:])
-    )
+    for prev_index, item in enumerate(items[1:]):
+        assert compare(items[prev_index], item)
 
 
 def setup_downvote(user: User, idea: Idea):
@@ -252,8 +251,10 @@ async def test_get_voted_ideas_returns_correct_ideas_and_correct_count_of_them(
         assert len(result.data) == votes_count
         assert result.count == votes_count
 
-        assert all(user.id in getattr(idea, idea_attr) for idea in result.data)
-        assert all(user.id not in getattr(idea, idea_attr) for idea in not_voted)
+        for idea in result.data:
+            assert user.id in getattr(idea, idea_attr)
+        for idea in not_voted:
+            assert user.id not in getattr(idea, idea_attr)
 
 
 @pytest.mark.integration

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -285,8 +285,12 @@ def test_create_access_token_encoded_token_has_correct_data(patch_jwt_secret_key
     decoded = jwt.decode(token, secret_key, algorithms=[JWT_ALGORITHM])
 
     assert "exp" in decoded
-    assert all(decoded[key] == value for key, value in data.items())
-    assert all(data[key] == value for key, value in decoded.items() if key != "exp")
+    for key, value in data.items():
+        assert decoded[key] == value
+    for key, value in decoded.items():
+        if key == "exp":
+            continue
+        assert data[key] == value
 
 
 @pytest.mark.parametrize(
@@ -340,8 +344,10 @@ def test_create_tokens_returns_two_tokens_and_refresh_token_expiration(
         refresh_token, secret_key, algorithms=[JWT_ALGORITHM]
     )
 
+    keys_expected_in_token = ("exp", "sub")
     for token in (decoded_access_token, decoded_refresh_token):
-        assert all(key in token for key in ("exp", "sub"))
+        for key in keys_expected_in_token:
+            assert key in token
         assert token["sub"] == user_id
 
     assert decoded_access_token["exp"] < decoded_refresh_token["exp"]

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -78,8 +78,7 @@ def test_get_settings_reads_individually_set_environment_variables(
 
             variables_not_modified = (env for env in env_variables if env != cur_key)
 
-            assert all(
-                getattr(config, key) != env_variables.get(key)
-                and getattr(config, key) == getattr(initial_config, key)
-                for key in variables_not_modified
-            )
+            for key in variables_not_modified:
+                value = getattr(config, key)
+                assert value != env_variables.get(key)
+                assert value == getattr(initial_config, key)


### PR DESCRIPTION
- Usually the change should be in the other direction.
- However, in tests with `assert`, using loop will give more information in case of fail, instead of `assert all(...)`.