### PR TITLE
refactor: move `assert_in_order` to util

### DIFF
--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.register_assert_rewrite("tests.util")

--- a/backend/tests/api/routes/test_users.py
+++ b/backend/tests/api/routes/test_users.py
@@ -10,7 +10,7 @@ from src.auth import get_current_user, verify_password
 from src.models import Idea, User
 from src.util import datetime_now
 
-from ...util import setup_users
+from ...util import assert_in_order, setup_users
 
 PREFIX = "/users"
 USERS_REGISTER = f"{PREFIX}/"
@@ -81,11 +81,6 @@ def url_for_user_id(user_id):
 
 def url_for_user_id_ideas(user_id):
     return f"{url_for_user_id(user_id)}/ideas/"
-
-
-def assert_in_order_by_name(items):
-    for prev_index, item in enumerate(items[1:]):
-        assert items[prev_index]["name"] <= item["name"]
 
 
 @asynccontextmanager
@@ -304,9 +299,9 @@ async def test_GET_users_returns_users_with_user_me_ordere_by_name(
     async with setup_users(real_db, additional_users):
         response = await admin_client.get(USERS)
         data = response.json()
-        users = data["users"]
+        user_names = [user["name"] for user in data["users"]]
 
-        assert_in_order_by_name(users)
+        assert_in_order(user_names)
 
 
 @pytest.mark.integration
@@ -498,9 +493,9 @@ async def test_GET_users_id_ideas_returns_user_ideas_in_data_ordered_by_name(
     user, _, _ = user_with_ideas
     response = await admin_client.get(url_for_user_id_ideas(user.id))
     data = response.json()
-    returned_ideas = data["data"]
+    returned_ideas_names = [idea["name"] for idea in data["data"]]
 
-    assert_in_order_by_name(returned_ideas)
+    assert_in_order(returned_ideas_names)
 
 
 @pytest.mark.integration

--- a/backend/tests/api/test_ideas.py
+++ b/backend/tests/api/test_ideas.py
@@ -1,4 +1,3 @@
-import operator
 import random
 from contextlib import contextmanager, suppress
 
@@ -16,13 +15,7 @@ from src.api.ideas import (
 from src.models import Idea, IdeaDownvote, IdeaUpvote, User
 
 from ..data_sample import idea1, user1
-from ..util import setup_ideas, setup_votes
-
-
-def assert_in_order(items, ascending=True):
-    compare = operator.le if ascending else operator.ge
-    for prev_index, item in enumerate(items[1:]):
-        assert compare(items[prev_index], item)
+from ..util import assert_in_order, setup_ideas, setup_votes
 
 
 def setup_downvote(user: User, idea: Idea):

--- a/backend/tests/util.py
+++ b/backend/tests/util.py
@@ -1,3 +1,4 @@
+import operator
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
@@ -12,6 +13,12 @@ from src.models import Idea, User
 from .data_sample import argon2_password_hash
 
 fake = faker.Faker()
+
+
+def assert_in_order(items, ascending=True):
+    compare = operator.le if ascending else operator.ge
+    for prev_index, item in enumerate(items[1:]):
+        assert compare(items[prev_index], item)
 
 
 def create_user(**options) -> User:


### PR DESCRIPTION
- Moves `assert_in_order` to `tests.util`.
- Removes function with similar functionality from different tests file.
- Registers `tests.util` to have asserts rewritten by pytest. This makes the potential assertion errors more user friendly. Pytest does that automatically in the files that contain tests, but not in ones without them.